### PR TITLE
The code changes primarily involve the addition of a private field `_…

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
 	<Product>Domain Primitives</Product>
 	<Company>ALTA Software llc.</Company>
 	<Copyright>Copyright © 2024 ALTA Software llc.</Copyright>
-	<Version>2.2.3</Version>
+	<Version>3.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AltaSoft.DomainPrimitives.Generator/Helpers/Constants.cs
+++ b/src/AltaSoft.DomainPrimitives.Generator/Helpers/Constants.cs
@@ -6,5 +6,6 @@
         internal const string SerializationFormatAttributeFullName = "AltaSoft.DomainPrimitives.SerializationFormatAttribute";
         internal const string SupportedOperationsAttribute = "SupportedOperationsAttribute";
         internal const string SupportedOperationsAttributeFullName = "AltaSoft.DomainPrimitives.SupportedOperationsAttribute";
+        internal const string StringLengthAttributeFullName = "AltaSoft.DomainPrimitives.StringLengthAttribute";
     }
 }

--- a/src/AltaSoft.DomainPrimitives.Generator/Helpers/MethodGeneratorHelper.cs
+++ b/src/AltaSoft.DomainPrimitives.Generator/Helpers/MethodGeneratorHelper.cs
@@ -87,11 +87,6 @@ internal static class MethodGeneratorHelper
                 var title = isNullable ? $"Nullable<{data.ClassName}>" : data.ClassName;
                 builder.Append("Title = ").Append(Quote(title)).AppendLine(",");
 
-                var defaultValue = CreateDefaultValue(data.UnderlyingType, data.ClassName, data.SerializationFormat);
-
-                if (defaultValue is not null)
-                    builder.Append("Default = ").Append(defaultValue).AppendLine(",");
-
                 if (!string.IsNullOrEmpty(xmlDocumentation))
                 {
                     var xmlDoc = new System.Xml.XmlDocument();
@@ -128,35 +123,35 @@ internal static class MethodGeneratorHelper
 
         static string Quote(string? value) => '\"' + value?.Replace("\"", "\"\"") + '\"';
 
-        static string? CreateDefaultValue(DomainPrimitiveUnderlyingType underlyingType, string className, string? serializationFormat)
-        {
-            return (underlyingType) switch
-            {
-                DomainPrimitiveUnderlyingType.String => $"new OpenApiString({className}.Default)",
-                DomainPrimitiveUnderlyingType.Guid => $"new OpenApiString({className}.Default.ToString())",
-                DomainPrimitiveUnderlyingType.Boolean => $"new OpenApiBoolean({className}.Default)",
-                DomainPrimitiveUnderlyingType.SByte => $"new OpenApiByte((byte){className}.Default)",
-                DomainPrimitiveUnderlyingType.Byte => $"new OpenApiByte({className}.Default)",
-                DomainPrimitiveUnderlyingType.Int16 => $"new OpenApiInteger({className}.Default)",
-                DomainPrimitiveUnderlyingType.UInt16 => $"new OpenApiInteger((short){className}.Default)",
-                DomainPrimitiveUnderlyingType.Int32 => $"new OpenApiInteger({className}.Default)",
-                DomainPrimitiveUnderlyingType.UInt32 => $"new OpenApiInteger((int){className}.Default)",
-                DomainPrimitiveUnderlyingType.Int64 => $"new OpenApiLong({className}.Default)",
-                DomainPrimitiveUnderlyingType.UInt64 => $"new OpenApiLong((long){className}.Default)",
-                DomainPrimitiveUnderlyingType.Decimal => $"new OpenApiDouble(decimal.ToDouble({className}.Default))",
-                DomainPrimitiveUnderlyingType.Single => $"new OpenApiFloat({className}.Default)",
-                DomainPrimitiveUnderlyingType.Double => $"new OpenApiDouble({className}.Default)",
-                DomainPrimitiveUnderlyingType.DateTime when serializationFormat is null => $"new OpenApiDateTime({className}.Default)",
-                DomainPrimitiveUnderlyingType.DateTime => $"new OpenApiString({className}.Default.ToString(\"{serializationFormat}\", null))",
-                DomainPrimitiveUnderlyingType.DateOnly => $"new OpenApiString({className}.Default.ToString(\"{serializationFormat ?? "YYYY-MM-DD"}\", null))",
-                DomainPrimitiveUnderlyingType.TimeOnly => $"new OpenApiString({className}.Default.ToString(\"{serializationFormat ?? "hh:mm:ss"}\", null))",
-                DomainPrimitiveUnderlyingType.TimeSpan => $"new OpenApiString({className}.Default.ToString(\"{serializationFormat ?? "hh:mm:ss"}\", null))",
-                DomainPrimitiveUnderlyingType.DateTimeOffset when serializationFormat is null => $"new OpenApiDateTime(((DateTimeOffset){className}.Default).DateTime)",
-                DomainPrimitiveUnderlyingType.DateTimeOffset => $"new OpenApiString({className}.Default.ToString(\"{serializationFormat}\", null))",
-                DomainPrimitiveUnderlyingType.Char => $"new OpenApiString({className}.Default.ToString())",
-                _ => null
-            };
-        }
+        //static string? CreateDefaultValue(DomainPrimitiveUnderlyingType underlyingType, string className, string? serializationFormat)
+        //{
+        //    return (underlyingType) switch
+        //    {
+        //        DomainPrimitiveUnderlyingType.String => $"new OpenApiString({className}.Default)",
+        //        DomainPrimitiveUnderlyingType.Guid => $"new OpenApiString({className}.Default.ToString())",
+        //        DomainPrimitiveUnderlyingType.Boolean => $"new OpenApiBoolean({className}.Default)",
+        //        DomainPrimitiveUnderlyingType.SByte => $"new OpenApiByte((byte){className}.Default)",
+        //        DomainPrimitiveUnderlyingType.Byte => $"new OpenApiByte({className}.Default)",
+        //        DomainPrimitiveUnderlyingType.Int16 => $"new OpenApiInteger({className}.Default)",
+        //        DomainPrimitiveUnderlyingType.UInt16 => $"new OpenApiInteger((short){className}.Default)",
+        //        DomainPrimitiveUnderlyingType.Int32 => $"new OpenApiInteger({className}.Default)",
+        //        DomainPrimitiveUnderlyingType.UInt32 => $"new OpenApiInteger((int){className}.Default)",
+        //        DomainPrimitiveUnderlyingType.Int64 => $"new OpenApiLong({className}.Default)",
+        //        DomainPrimitiveUnderlyingType.UInt64 => $"new OpenApiLong((long){className}.Default)",
+        //        DomainPrimitiveUnderlyingType.Decimal => $"new OpenApiDouble(decimal.ToDouble({className}.Default))",
+        //        DomainPrimitiveUnderlyingType.Single => $"new OpenApiFloat({className}.Default)",
+        //        DomainPrimitiveUnderlyingType.Double => $"new OpenApiDouble({className}.Default)",
+        //        DomainPrimitiveUnderlyingType.DateTime when serializationFormat is null => $"new OpenApiDateTime({className}.Default)",
+        //        DomainPrimitiveUnderlyingType.DateTime => $"new OpenApiString({className}.Default.ToString(\"{serializationFormat}\", null))",
+        //        DomainPrimitiveUnderlyingType.DateOnly => $"new OpenApiString({className}.Default.ToString(\"{serializationFormat ?? "YYYY-MM-DD"}\", null))",
+        //        DomainPrimitiveUnderlyingType.TimeOnly => $"new OpenApiString({className}.Default.ToString(\"{serializationFormat ?? "hh:mm:ss"}\", null))",
+        //        DomainPrimitiveUnderlyingType.TimeSpan => $"new OpenApiString({className}.Default.ToString(\"{serializationFormat ?? "hh:mm:ss"}\", null))",
+        //        DomainPrimitiveUnderlyingType.DateTimeOffset when serializationFormat is null => $"new OpenApiDateTime(((DateTimeOffset){className}.Default).DateTime)",
+        //        DomainPrimitiveUnderlyingType.DateTimeOffset => $"new OpenApiString({className}.Default.ToString(\"{serializationFormat}\", null))",
+        //        DomainPrimitiveUnderlyingType.Char => $"new OpenApiString({className}.Default.ToString())",
+        //        _ => null
+        //    };
+        //}
     }
 
     /// <summary>
@@ -747,7 +742,7 @@ internal static class MethodGeneratorHelper
         builder.AppendLine("public void ReadXml(XmlReader reader)")
             .OpenBracket()
             .Append("System.Runtime.CompilerServices.Unsafe.AsRef(in _value) = reader.").Append(method).AppendLine("();")
-            .AppendLineIf(data.GenerateIsInitializedField, "System.Runtime.CompilerServices.Unsafe.AsRef(in _isInitialized) = true;")
+            .AppendLine("System.Runtime.CompilerServices.Unsafe.AsRef(in _isInitialized) = true;")
             .CloseBracket()
             .NewLine();
 

--- a/src/AltaSoft.DomainPrimitives.Generator/Models/GeneratorData.cs
+++ b/src/AltaSoft.DomainPrimitives.Generator/Models/GeneratorData.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.CodeAnalysis;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
 
 namespace AltaSoft.DomainPrimitives.Generator.Models;
 
@@ -52,11 +52,6 @@ internal sealed class GeneratorData
     /// Gets the class name.
     /// </summary>
     public string ClassName => TypeSymbol.Name;
-
-    /// <summary>
-    /// Gets or sets a value indicating whether to generate _isInitialized field.
-    /// </summary>
-    public bool GenerateIsInitializedField { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether to generate subtraction operators.

--- a/src/AltaSoft.DomainPrimitives.XmlDataTypes/AsciiString.cs
+++ b/src/AltaSoft.DomainPrimitives.XmlDataTypes/AsciiString.cs
@@ -21,7 +21,4 @@ public partial class AsciiString : IDomainValue<string>
                 throw new InvalidDomainValueException("value contains non-ascii characters");
         }
     }
-
-    /// <inheritdoc/>
-    public static string Default => string.Empty;
 }

--- a/src/AltaSoft.DomainPrimitives.XmlDataTypes/GDay.cs
+++ b/src/AltaSoft.DomainPrimitives.XmlDataTypes/GDay.cs
@@ -17,8 +17,5 @@ public readonly partial struct GDay : IDomainValue<DateOnly>
     { }
 
     /// <inheritdoc/>
-    public static DateOnly Default => default;
-
-    /// <inheritdoc/>
     public static string ToString(DateOnly value) => value.ToString("dd", CultureInfo.InvariantCulture);
 }

--- a/src/AltaSoft.DomainPrimitives.XmlDataTypes/GMonth.cs
+++ b/src/AltaSoft.DomainPrimitives.XmlDataTypes/GMonth.cs
@@ -17,8 +17,5 @@ public readonly partial struct GMonth : IDomainValue<DateOnly>
     { }
 
     /// <inheritdoc/>
-    public static DateOnly Default => default;
-
-    /// <inheritdoc/>
     public static string ToString(DateOnly value) => value.ToString("MM", CultureInfo.InvariantCulture);
 }

--- a/src/AltaSoft.DomainPrimitives.XmlDataTypes/GMonthDay.cs
+++ b/src/AltaSoft.DomainPrimitives.XmlDataTypes/GMonthDay.cs
@@ -17,8 +17,5 @@ public readonly partial struct GMonthDay : IDomainValue<DateOnly>
     { }
 
     /// <inheritdoc/>
-    public static DateOnly Default => default;
-
-    /// <inheritdoc/>
     public static string ToString(DateOnly value) => value.ToString("MM-dd", CultureInfo.InvariantCulture);
 }

--- a/src/AltaSoft.DomainPrimitives.XmlDataTypes/GYear.cs
+++ b/src/AltaSoft.DomainPrimitives.XmlDataTypes/GYear.cs
@@ -17,8 +17,5 @@ public readonly partial struct GYear : IDomainValue<DateOnly>
     { }
 
     /// <inheritdoc/>
-    public static DateOnly Default => default;
-
-    /// <inheritdoc/>
     public static string ToString(DateOnly value) => value.ToString("yyyy", CultureInfo.InvariantCulture);
 }

--- a/src/AltaSoft.DomainPrimitives.XmlDataTypes/GYearMonth.cs
+++ b/src/AltaSoft.DomainPrimitives.XmlDataTypes/GYearMonth.cs
@@ -17,8 +17,5 @@ public readonly partial struct GYearMonth : IDomainValue<DateOnly>
     { }
 
     /// <inheritdoc/>
-    public static DateOnly Default => default;
-
-    /// <inheritdoc/>
     public static string ToString(DateOnly value) => value.ToString("yyyy-MM", CultureInfo.InvariantCulture);
 }

--- a/src/AltaSoft.DomainPrimitives.XmlDataTypes/NegativeInteger.cs
+++ b/src/AltaSoft.DomainPrimitives.XmlDataTypes/NegativeInteger.cs
@@ -17,7 +17,4 @@ public readonly partial struct NegativeInteger : IDomainValue<int>
         if (value >= 0)
             throw new InvalidDomainValueException("value is non-negative");
     }
-
-    /// <inheritdoc/>
-    public static int Default => -1;
 }

--- a/src/AltaSoft.DomainPrimitives.XmlDataTypes/NonEmptyString.cs
+++ b/src/AltaSoft.DomainPrimitives.XmlDataTypes/NonEmptyString.cs
@@ -6,6 +6,7 @@
 /// <remarks>
 /// The NonEmptyString ensures that its value is a non-empty string.
 /// </remarks>
+[StringLength(1, int.MaxValue)]
 public partial class NonEmptyString : IDomainValue<string>
 {
     /// <inheritdoc/>
@@ -14,9 +15,4 @@ public partial class NonEmptyString : IDomainValue<string>
         if (string.IsNullOrEmpty(value))
             throw new InvalidDomainValueException("value is empty string");
     }
-
-    /// <summary>
-    /// Gets the default value for NonEmptyString, which is "N/A".
-    /// </summary>
-    public static string Default => "N/A";
 }

--- a/src/AltaSoft.DomainPrimitives.XmlDataTypes/NonNegativeInteger.cs
+++ b/src/AltaSoft.DomainPrimitives.XmlDataTypes/NonNegativeInteger.cs
@@ -17,7 +17,4 @@ public readonly partial struct NonNegativeInteger : IDomainValue<int>
         if (value < 0)
             throw new InvalidDomainValueException("value is negative");
     }
-
-    /// <inheritdoc/>
-    public static int Default => 0;
 }

--- a/src/AltaSoft.DomainPrimitives.XmlDataTypes/NonPositiveInteger.cs
+++ b/src/AltaSoft.DomainPrimitives.XmlDataTypes/NonPositiveInteger.cs
@@ -17,7 +17,4 @@ public readonly partial struct NonPositiveInteger : IDomainValue<int>
         if (value > 0)
             throw new InvalidDomainValueException("value is positive");
     }
-
-    /// <inheritdoc/>
-    public static int Default => 0;
 }

--- a/src/AltaSoft.DomainPrimitives.XmlDataTypes/PositiveInteger.cs
+++ b/src/AltaSoft.DomainPrimitives.XmlDataTypes/PositiveInteger.cs
@@ -17,7 +17,4 @@ public readonly partial struct PositiveInteger : IDomainValue<int>
         if (value <= 0)
             throw new InvalidDomainValueException("value is non-positive");
     }
-
-    /// <inheritdoc/>
-    public static int Default => 1;
 }

--- a/src/AltaSoft.DomainPrimitives/IDomainValue.cs
+++ b/src/AltaSoft.DomainPrimitives/IDomainValue.cs
@@ -7,7 +7,7 @@ namespace AltaSoft.DomainPrimitives;
 /// This interface serves as a foundation for encapsulating and validating domain-specific values.
 /// </summary>
 /// <typeparam name="T">The type of the domain value.</typeparam>
-public interface IDomainValue<T> : IDomainValue
+public interface IDomainValue<in T> : IDomainValue
     where T : IEquatable<T>, IComparable, IComparable<T>
 {
     /// <summary>
@@ -16,11 +16,6 @@ public interface IDomainValue<T> : IDomainValue
     /// <param name="value">The value to be validated against domain constraints.</param>
     /// <exception cref="InvalidDomainValueException">Thrown when validation fails due to domain-specific constraints.</exception>
     static abstract void Validate(T value);
-
-    /// <summary>
-    /// Retrieves the default value representing the expected state within the domain.
-    /// </summary>
-    static abstract T Default { get; }
 
     /// <summary>
     /// Retrieves a string representation of the specified domain value.

--- a/src/AltaSoft.DomainPrimitives/StringLengthAttribute.cs
+++ b/src/AltaSoft.DomainPrimitives/StringLengthAttribute.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace AltaSoft.DomainPrimitives;
+
+/// <summary>
+/// Validation attribute to assert a string property, field or parameter does not exceed a maximum length
+/// </summary>
+[AttributeUsage(AttributeTargets.Class)]
+public class StringLengthAttribute : Attribute
+{
+    /// <summary>
+    /// Constructor that accepts the minimum and maximum lengths of the string.
+    /// </summary>
+    /// <param name="minimumLength">The minimum length, inclusive. It may not be negative.</param>
+    /// <param name="maximumLength">The maximum length, inclusive. It may not be negative.</param>
+    public StringLengthAttribute(int minimumLength, int maximumLength)
+    {
+        MinimumLength = minimumLength;
+        MaximumLength = maximumLength;
+    }
+
+    /// <summary>
+    /// Gets the maximum acceptable length of the string
+    /// </summary>
+    public int MaximumLength { get; }
+
+    /// <summary>
+    /// Gets or sets the minimum acceptable length of the string
+    /// </summary>
+    public int MinimumLength { get; set; }
+}

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/DomainPrimitiveGeneratorTest.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/DomainPrimitiveGeneratorTest.cs
@@ -22,15 +22,12 @@ public class DomainPrimitiveGeneratorTest
 		                      /// <inheritdoc/>
 		                      public partial class StringValue : IDomainValue<string>
 		                      {
-		                      /// <inheritdoc/>
-		                      public static void Validate(string value)
-		                      {
-		                          if (value=="Test")
-		                              throw new InvalidDomainValueException("Invalid Value");
-		                      }
-
-		                      /// <inheritdoc/>
-		                      public static string Default => default;
+		                          /// <inheritdoc/>
+		                          public static void Validate(string value)
+		                          {
+		                              if (value=="Test")
+		                                  throw new InvalidDomainValueException("Invalid Value");
+		                          }
 		                      }
 		                      """;
 
@@ -59,9 +56,6 @@ public class DomainPrimitiveGeneratorTest
 		             		if (value==default)
 		             			throw new InvalidDomainValueException("Invalid Value");
 		             	}
-
-		             	/// <inheritdoc/>
-		             	public static Guid Default => default;
 		             }
 		             """;
 
@@ -90,9 +84,6 @@ public class DomainPrimitiveGeneratorTest
 		             		if (!value)
 		             			throw new InvalidDomainValueException("Invalid Value");
 		             	}
-
-		             	/// <inheritdoc/>
-		             	public static bool Default => default;
 		             }
 		             """;
 
@@ -121,9 +112,6 @@ public class DomainPrimitiveGeneratorTest
 		             		if (value < 10 || value > 20)
 		             			throw new InvalidDomainValueException("Invalid Value");
 		             	}
-
-		             	/// <inheritdoc/>
-		             	public static SByte Default => default;
 		             }
 		             """;
 
@@ -152,9 +140,6 @@ public class DomainPrimitiveGeneratorTest
 		             		if (value < 0)
 		             			throw new InvalidDomainValueException("Invalid Value");
 		             	}
-
-		             	/// <inheritdoc/>
-		             	public static byte Default => default;
 		             }
 		             """;
 
@@ -183,9 +168,6 @@ public class DomainPrimitiveGeneratorTest
 		             		if (value < 0)
 		             			throw new InvalidDomainValueException("Invalid Value");
 		             	}
-
-		             	/// <inheritdoc/>
-		             	public static short Default => default;
 		             }
 		             """;
 
@@ -214,9 +196,6 @@ public class DomainPrimitiveGeneratorTest
 		             		if (value > 100)
 		             			throw new InvalidDomainValueException("Value must be between 10 and 100");
 		             	}
-
-		             	/// <inheritdoc/>
-		             	public static ushort Default => default;
 		             }
 		             """;
 
@@ -245,9 +224,6 @@ public class DomainPrimitiveGeneratorTest
 		             		if (value < 10 || value > 20)
 		             			throw new InvalidDomainValueException("Invalid Value");
 		             	}
-
-		             	/// <inheritdoc/>
-		             	public static int Default => default;
 		             }
 		             """;
 
@@ -276,9 +252,6 @@ public class DomainPrimitiveGeneratorTest
 		             		if (value < 10 || value > 20)
 		             			throw new InvalidDomainValueException("Invalid Value");
 		             	}
-
-		             	/// <inheritdoc/>
-		             	public static uint Default => default;
 		             }
 		             """;
 
@@ -307,9 +280,6 @@ public class DomainPrimitiveGeneratorTest
 		             		if (value < 0)
 		             			throw new InvalidDomainValueException("Invalid Value");
 		             	}
-
-		             	/// <inheritdoc/>
-		             	public static long Default => default;
 		             }
 		             """;
 
@@ -338,9 +308,6 @@ public class DomainPrimitiveGeneratorTest
 		             		if (value < 0)
 		             			throw new InvalidDomainValueException("Invalid Value");
 		             	}
-
-		             	/// <inheritdoc/>
-		             	public static ulong Default => default;
 		             }
 		             """;
 
@@ -368,9 +335,6 @@ public class DomainPrimitiveGeneratorTest
 		             		if (value < 0)
 		             			throw new InvalidDomainValueException("Invalid Value");
 		             	}
-
-		             	/// <inheritdoc/>
-		             	public static decimal Default => default;
 		             }
 		             """;
 
@@ -398,9 +362,6 @@ public class DomainPrimitiveGeneratorTest
 		             		if (value < 0)
 		             			throw new InvalidDomainValueException("Invalid Value");
 		             	}
-
-		             	/// <inheritdoc/>
-		             	public static float Default => default;
 		             }
 		             """;
 
@@ -428,9 +389,6 @@ public class DomainPrimitiveGeneratorTest
 		             		if (value < 0)
 		             			throw new InvalidDomainValueException("Invalid Value");
 		             	}
-
-		             	/// <inheritdoc/>
-		             	public static double Default => default;
 		             }
 		             """;
 
@@ -458,9 +416,6 @@ public class DomainPrimitiveGeneratorTest
 		             		if (value == default)
 		             			throw new InvalidDomainValueException("Invalid Value");
 		             	}
-
-		             	/// <inheritdoc/>
-		             	public static DateTime Default => default;
 		             }
 
 		             """;
@@ -489,9 +444,6 @@ public class DomainPrimitiveGeneratorTest
 		             		if (value == default)
 		             			throw new InvalidDomainValueException("Invalid Value");
 		             	}
-
-		             	/// <inheritdoc/>
-		             	public static DateOnly Default => default;
 		             }
 
 		             """;
@@ -520,9 +472,6 @@ public class DomainPrimitiveGeneratorTest
 		             		if (value == default)
 		             			throw new InvalidDomainValueException("Invalid Value");
 		             	}
-
-		             	/// <inheritdoc/>
-		             	public static TimeOnly Default => default;
 		             }
 
 		             """;
@@ -551,9 +500,6 @@ public class DomainPrimitiveGeneratorTest
 		             		if (value == default)
 		             			throw new InvalidDomainValueException("Invalid Value");
 		             	}
-
-		             	/// <inheritdoc/>
-		             	public static TimeSpan Default => default;
 		             }
 
 		             """;
@@ -582,9 +528,6 @@ public class DomainPrimitiveGeneratorTest
 		             		if (value == default)
 		             			throw new InvalidDomainValueException("Invalid Value");
 		             	}
-
-		             	/// <inheritdoc/>
-		             	public static DateTimeOffset Default => default;
 		             }
 
 		             """;
@@ -613,9 +556,6 @@ public class DomainPrimitiveGeneratorTest
 		                      		if (value == default)
 		                      			throw new InvalidDomainValueException("Invalid Value");
 		                      	}
-
-		                      	/// <inheritdoc/>
-		                      	public static char Default => default;
 		                      }
 
 		                      """;
@@ -639,29 +579,23 @@ public class DomainPrimitiveGeneratorTest
                               /// <inheritdoc/>
                               public partial class StringValue : IDomainValue<string>
                               {
-                              /// <inheritdoc/>
-                              public static void Validate(string value)
-                              {
-                                  if (value=="Test")
-                                      throw new InvalidDomainValueException("Invalid Value");
-                              }
-
-                              /// <inheritdoc/>
-                              public static string Default => default;
+                                  /// <inheritdoc/>
+                                  public static void Validate(string value)
+                                  {
+                                      if (value=="Test")
+                                          throw new InvalidDomainValueException("Invalid Value");
+                                  }
                               }
 
                               /// <inheritdoc/>
                               public partial class StringOfStringValue : IDomainValue<StringValue>
                               {
-                              /// <inheritdoc/>
-                              public static void Validate(StringValue value)
-                              {
-                                  if (value=="Test")
-                                      throw new InvalidDomainValueException("Invalid Value");
-                              }
-
-                              /// <inheritdoc/>
-                              public static StringValue Default => default;
+                                  /// <inheritdoc/>
+                                  public static void Validate(StringValue value)
+                                  {
+                                      if (value=="Test")
+                                          throw new InvalidDomainValueException("Invalid Value");
+                                  }
                               }
                               """;
 
@@ -690,9 +624,6 @@ public class DomainPrimitiveGeneratorTest
                               		if (value < 10 || value > 20)
                               			throw new InvalidDomainValueException("Invalid Value");
                               	}
-
-                              	/// <inheritdoc/>
-                              	public static int Default => default;
                               }
 
                               /// <inheritdoc/>
@@ -704,9 +635,6 @@ public class DomainPrimitiveGeneratorTest
                                     		if (value < 10 || value > 20)
                                        			throw new InvalidDomainValueException("Invalid Value");
                                  	}
-
-                                 	/// <inheritdoc/>
-                                 	public static IntValue Default => default;
                               }
                               """;
 

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.BoolValue_GeneratesAllInterfacesAndConverters#BoolValue.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.BoolValue_GeneratesAllInterfacesAndConverters#BoolValue.g.verified.cs
@@ -35,8 +35,11 @@ public readonly partial struct BoolValue : IEquatable<BoolValue>
     /// <inheritdoc/>
      public object GetUnderlyingPrimitiveValue() => (bool)this;
 
+    private bool _valueOrThrow => _isInitialized ? _value : throw new InvalidDomainValueException("The domain value has not been initialized");
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly bool _value;
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly bool _isInitialized;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BoolValue"/> class by validating the specified <see cref="bool"/> value using <see cref="Validate"/> static method.
@@ -46,13 +49,13 @@ public readonly partial struct BoolValue : IEquatable<BoolValue>
     {
         Validate(value);
         _value = value;
+        _isInitialized = true;
     }
 
     /// <inheritdoc/>
     [Obsolete("Domain primitive cannot be created using empty Ctor", true)]
     public BoolValue()
     {
-        _value = Default;
     }
 
     /// <inheritdoc/>
@@ -60,7 +63,7 @@ public readonly partial struct BoolValue : IEquatable<BoolValue>
     public override bool Equals(object? obj) => obj is BoolValue other && Equals(other);
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Equals(BoolValue other) => _value == other._value;
+    public bool Equals(BoolValue other) => _valueOrThrow == other._valueOrThrow;
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator ==(BoolValue left, BoolValue right) => left.Equals(right);
@@ -81,7 +84,7 @@ public readonly partial struct BoolValue : IEquatable<BoolValue>
     }
 
     /// <inheritdoc/>
-    public int CompareTo(BoolValue other) => _value.CompareTo(other._value);
+    public int CompareTo(BoolValue other) => _valueOrThrow.CompareTo(other._valueOrThrow);
 
     /// <summary>
     /// Implicit conversion from <see cref = "bool"/> to <see cref = "BoolValue"/>
@@ -100,14 +103,14 @@ public readonly partial struct BoolValue : IEquatable<BoolValue>
     /// Implicit conversion from <see cref = "BoolValue"/> to <see cref = "bool"/>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator bool(BoolValue value) => (bool)value._value;
+    public static implicit operator bool(BoolValue value) => (bool)value._valueOrThrow;
 
     /// <summary>
     /// Implicit conversion from <see cref = "BoolValue"/> (nullable) to <see cref = "bool"/> (nullable)
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [return: NotNullIfNotNull(nameof(value))]
-    public static implicit operator bool?(BoolValue? value) => value is null ? null : (bool?)value.Value._value;
+    public static implicit operator bool?(BoolValue? value) => value is null ? null : (bool?)value.Value._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -137,61 +140,61 @@ public readonly partial struct BoolValue : IEquatable<BoolValue>
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override int GetHashCode() => _value.GetHashCode();
+    public override int GetHashCode() => _valueOrThrow.GetHashCode();
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(Boolean)_value).GetTypeCode();
+    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(Boolean)_valueOrThrow).GetTypeCode();
 
     /// <inheritdoc/>
-    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(Boolean)_value).ToBoolean(provider);
+    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(Boolean)_valueOrThrow).ToBoolean(provider);
 
     /// <inheritdoc/>
-    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(Boolean)_value).ToByte(provider);
+    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(Boolean)_valueOrThrow).ToByte(provider);
 
     /// <inheritdoc/>
-    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(Boolean)_value).ToChar(provider);
+    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(Boolean)_valueOrThrow).ToChar(provider);
 
     /// <inheritdoc/>
-    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(Boolean)_value).ToDateTime(provider);
+    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(Boolean)_valueOrThrow).ToDateTime(provider);
 
     /// <inheritdoc/>
-    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(Boolean)_value).ToDecimal(provider);
+    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(Boolean)_valueOrThrow).ToDecimal(provider);
 
     /// <inheritdoc/>
-    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(Boolean)_value).ToDouble(provider);
+    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(Boolean)_valueOrThrow).ToDouble(provider);
 
     /// <inheritdoc/>
-    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(Boolean)_value).ToInt16(provider);
+    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(Boolean)_valueOrThrow).ToInt16(provider);
 
     /// <inheritdoc/>
-    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(Boolean)_value).ToInt32(provider);
+    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(Boolean)_valueOrThrow).ToInt32(provider);
 
     /// <inheritdoc/>
-    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(Boolean)_value).ToInt64(provider);
+    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(Boolean)_valueOrThrow).ToInt64(provider);
 
     /// <inheritdoc/>
-    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(Boolean)_value).ToSByte(provider);
+    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(Boolean)_valueOrThrow).ToSByte(provider);
 
     /// <inheritdoc/>
-    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(Boolean)_value).ToSingle(provider);
+    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(Boolean)_valueOrThrow).ToSingle(provider);
 
     /// <inheritdoc/>
-    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(Boolean)_value).ToString(provider);
+    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(Boolean)_valueOrThrow).ToString(provider);
 
     /// <inheritdoc/>
-    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(Boolean)_value).ToType(conversionType, provider);
+    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(Boolean)_valueOrThrow).ToType(conversionType, provider);
 
     /// <inheritdoc/>
-    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(Boolean)_value).ToUInt16(provider);
+    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(Boolean)_valueOrThrow).ToUInt16(provider);
 
     /// <inheritdoc/>
-    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(Boolean)_value).ToUInt32(provider);
+    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(Boolean)_valueOrThrow).ToUInt32(provider);
 
     /// <inheritdoc/>
-    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(Boolean)_value).ToUInt64(provider);
+    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(Boolean)_valueOrThrow).ToUInt64(provider);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override string ToString() => _value.ToString();
+    public override string ToString() => _valueOrThrow.ToString();
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.BoolValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.BoolValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
@@ -35,15 +35,13 @@ public static class SwaggerTypeHelper
         options.MapType<BoolValue>(() => new OpenApiSchema
         {
             Type = "boolean",
-            Title = "BoolValue",
-            Default = new OpenApiBoolean(BoolValue.Default)
+            Title = "BoolValue"
         });
         options.MapType<BoolValue?>(() => new OpenApiSchema
         {
             Type = "boolean",
             Nullable = true,
-            Title = "Nullable<BoolValue>",
-            Default = new OpenApiBoolean(BoolValue.Default)
+            Title = "Nullable<BoolValue>"
         });
     }
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.ByteValue_GeneratesAllInterfacesAndConverters#ByteValue.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.ByteValue_GeneratesAllInterfacesAndConverters#ByteValue.g.verified.cs
@@ -39,8 +39,11 @@ public readonly partial struct ByteValue : IEquatable<ByteValue>
     /// <inheritdoc/>
      public object GetUnderlyingPrimitiveValue() => (byte)this;
 
+    private byte _valueOrThrow => _isInitialized ? _value : throw new InvalidDomainValueException("The domain value has not been initialized");
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly byte _value;
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly bool _isInitialized;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ByteValue"/> class by validating the specified <see cref="byte"/> value using <see cref="Validate"/> static method.
@@ -50,13 +53,13 @@ public readonly partial struct ByteValue : IEquatable<ByteValue>
     {
         Validate(value);
         _value = value;
+        _isInitialized = true;
     }
 
     /// <inheritdoc/>
     [Obsolete("Domain primitive cannot be created using empty Ctor", true)]
     public ByteValue()
     {
-        _value = Default;
     }
 
     /// <inheritdoc/>
@@ -64,7 +67,7 @@ public readonly partial struct ByteValue : IEquatable<ByteValue>
     public override bool Equals(object? obj) => obj is ByteValue other && Equals(other);
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Equals(ByteValue other) => _value == other._value;
+    public bool Equals(ByteValue other) => _valueOrThrow == other._valueOrThrow;
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator ==(ByteValue left, ByteValue right) => left.Equals(right);
@@ -85,7 +88,7 @@ public readonly partial struct ByteValue : IEquatable<ByteValue>
     }
 
     /// <inheritdoc/>
-    public int CompareTo(ByteValue other) => _value.CompareTo(other._value);
+    public int CompareTo(ByteValue other) => _valueOrThrow.CompareTo(other._valueOrThrow);
 
     /// <summary>
     /// Implicit conversion from <see cref = "byte"/> to <see cref = "ByteValue"/>
@@ -104,30 +107,30 @@ public readonly partial struct ByteValue : IEquatable<ByteValue>
     /// Implicit conversion from <see cref = "ByteValue"/> to <see cref = "byte"/>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator byte(ByteValue value) => (byte)value._value;
+    public static implicit operator byte(ByteValue value) => (byte)value._valueOrThrow;
 
     /// <summary>
     /// Implicit conversion from <see cref = "ByteValue"/> (nullable) to <see cref = "byte"/> (nullable)
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [return: NotNullIfNotNull(nameof(value))]
-    public static implicit operator byte?(ByteValue? value) => value is null ? null : (byte?)value.Value._value;
+    public static implicit operator byte?(ByteValue? value) => value is null ? null : (byte?)value.Value._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <(ByteValue left, ByteValue right) => left._value < right._value;
+    public static bool operator <(ByteValue left, ByteValue right) => left._valueOrThrow < right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <=(ByteValue left, ByteValue right) => left._value <= right._value;
+    public static bool operator <=(ByteValue left, ByteValue right) => left._valueOrThrow <= right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >(ByteValue left, ByteValue right) => left._value > right._value;
+    public static bool operator >(ByteValue left, ByteValue right) => left._valueOrThrow > right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >=(ByteValue left, ByteValue right) => left._value >= right._value;
+    public static bool operator >=(ByteValue left, ByteValue right) => left._valueOrThrow >= right._valueOrThrow;
 
 
     /// <inheritdoc/>
@@ -161,67 +164,67 @@ public readonly partial struct ByteValue : IEquatable<ByteValue>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
     {
-        return ((IUtf8SpanFormattable)_value).TryFormat(utf8Destination, out bytesWritten, format, provider);
+        return ((IUtf8SpanFormattable)_valueOrThrow).TryFormat(utf8Destination, out bytesWritten, format, provider);
     }
 #endif
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override int GetHashCode() => _value.GetHashCode();
+    public override int GetHashCode() => _valueOrThrow.GetHashCode();
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(Byte)_value).GetTypeCode();
+    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(Byte)_valueOrThrow).GetTypeCode();
 
     /// <inheritdoc/>
-    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(Byte)_value).ToBoolean(provider);
+    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(Byte)_valueOrThrow).ToBoolean(provider);
 
     /// <inheritdoc/>
-    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(Byte)_value).ToByte(provider);
+    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(Byte)_valueOrThrow).ToByte(provider);
 
     /// <inheritdoc/>
-    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(Byte)_value).ToChar(provider);
+    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(Byte)_valueOrThrow).ToChar(provider);
 
     /// <inheritdoc/>
-    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(Byte)_value).ToDateTime(provider);
+    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(Byte)_valueOrThrow).ToDateTime(provider);
 
     /// <inheritdoc/>
-    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(Byte)_value).ToDecimal(provider);
+    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(Byte)_valueOrThrow).ToDecimal(provider);
 
     /// <inheritdoc/>
-    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(Byte)_value).ToDouble(provider);
+    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(Byte)_valueOrThrow).ToDouble(provider);
 
     /// <inheritdoc/>
-    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(Byte)_value).ToInt16(provider);
+    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(Byte)_valueOrThrow).ToInt16(provider);
 
     /// <inheritdoc/>
-    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(Byte)_value).ToInt32(provider);
+    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(Byte)_valueOrThrow).ToInt32(provider);
 
     /// <inheritdoc/>
-    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(Byte)_value).ToInt64(provider);
+    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(Byte)_valueOrThrow).ToInt64(provider);
 
     /// <inheritdoc/>
-    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(Byte)_value).ToSByte(provider);
+    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(Byte)_valueOrThrow).ToSByte(provider);
 
     /// <inheritdoc/>
-    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(Byte)_value).ToSingle(provider);
+    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(Byte)_valueOrThrow).ToSingle(provider);
 
     /// <inheritdoc/>
-    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(Byte)_value).ToString(provider);
+    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(Byte)_valueOrThrow).ToString(provider);
 
     /// <inheritdoc/>
-    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(Byte)_value).ToType(conversionType, provider);
+    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(Byte)_valueOrThrow).ToType(conversionType, provider);
 
     /// <inheritdoc/>
-    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(Byte)_value).ToUInt16(provider);
+    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(Byte)_valueOrThrow).ToUInt16(provider);
 
     /// <inheritdoc/>
-    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(Byte)_value).ToUInt32(provider);
+    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(Byte)_valueOrThrow).ToUInt32(provider);
 
     /// <inheritdoc/>
-    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(Byte)_value).ToUInt64(provider);
+    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(Byte)_valueOrThrow).ToUInt64(provider);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override string ToString() => _value.ToString();
+    public override string ToString() => _valueOrThrow.ToString();
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.ByteValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.ByteValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
@@ -36,16 +36,14 @@ public static class SwaggerTypeHelper
         {
             Type = "integer",
             Format = "byte",
-            Title = "ByteValue",
-            Default = new OpenApiByte(ByteValue.Default)
+            Title = "ByteValue"
         });
         options.MapType<ByteValue?>(() => new OpenApiSchema
         {
             Type = "integer",
             Format = "byte",
             Nullable = true,
-            Title = "Nullable<ByteValue>",
-            Default = new OpenApiByte(ByteValue.Default)
+            Title = "Nullable<ByteValue>"
         });
     }
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.CharValue_GeneratesAllInterfacesAndConverters#CharValue.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.CharValue_GeneratesAllInterfacesAndConverters#CharValue.g.verified.cs
@@ -39,8 +39,11 @@ public readonly partial struct CharValue : IEquatable<CharValue>
     /// <inheritdoc/>
      public object GetUnderlyingPrimitiveValue() => (char)this;
 
+    private char _valueOrThrow => _isInitialized ? _value : throw new InvalidDomainValueException("The domain value has not been initialized");
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly char _value;
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly bool _isInitialized;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CharValue"/> class by validating the specified <see cref="char"/> value using <see cref="Validate"/> static method.
@@ -50,13 +53,13 @@ public readonly partial struct CharValue : IEquatable<CharValue>
     {
         Validate(value);
         _value = value;
+        _isInitialized = true;
     }
 
     /// <inheritdoc/>
     [Obsolete("Domain primitive cannot be created using empty Ctor", true)]
     public CharValue()
     {
-        _value = Default;
     }
 
     /// <inheritdoc/>
@@ -64,7 +67,7 @@ public readonly partial struct CharValue : IEquatable<CharValue>
     public override bool Equals(object? obj) => obj is CharValue other && Equals(other);
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Equals(CharValue other) => _value == other._value;
+    public bool Equals(CharValue other) => _valueOrThrow == other._valueOrThrow;
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator ==(CharValue left, CharValue right) => left.Equals(right);
@@ -85,7 +88,7 @@ public readonly partial struct CharValue : IEquatable<CharValue>
     }
 
     /// <inheritdoc/>
-    public int CompareTo(CharValue other) => _value.CompareTo(other._value);
+    public int CompareTo(CharValue other) => _valueOrThrow.CompareTo(other._valueOrThrow);
 
     /// <summary>
     /// Implicit conversion from <see cref = "char"/> to <see cref = "CharValue"/>
@@ -104,30 +107,30 @@ public readonly partial struct CharValue : IEquatable<CharValue>
     /// Implicit conversion from <see cref = "CharValue"/> to <see cref = "char"/>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator char(CharValue value) => (char)value._value;
+    public static implicit operator char(CharValue value) => (char)value._valueOrThrow;
 
     /// <summary>
     /// Implicit conversion from <see cref = "CharValue"/> (nullable) to <see cref = "char"/> (nullable)
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [return: NotNullIfNotNull(nameof(value))]
-    public static implicit operator char?(CharValue? value) => value is null ? null : (char?)value.Value._value;
+    public static implicit operator char?(CharValue? value) => value is null ? null : (char?)value.Value._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <(CharValue left, CharValue right) => left._value < right._value;
+    public static bool operator <(CharValue left, CharValue right) => left._valueOrThrow < right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <=(CharValue left, CharValue right) => left._value <= right._value;
+    public static bool operator <=(CharValue left, CharValue right) => left._valueOrThrow <= right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >(CharValue left, CharValue right) => left._value > right._value;
+    public static bool operator >(CharValue left, CharValue right) => left._valueOrThrow > right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >=(CharValue left, CharValue right) => left._value >= right._value;
+    public static bool operator >=(CharValue left, CharValue right) => left._valueOrThrow >= right._valueOrThrow;
 
 
     /// <inheritdoc/>
@@ -161,67 +164,67 @@ public readonly partial struct CharValue : IEquatable<CharValue>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
     {
-        return ((IUtf8SpanFormattable)_value).TryFormat(utf8Destination, out bytesWritten, format, provider);
+        return ((IUtf8SpanFormattable)_valueOrThrow).TryFormat(utf8Destination, out bytesWritten, format, provider);
     }
 #endif
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override int GetHashCode() => _value.GetHashCode();
+    public override int GetHashCode() => _valueOrThrow.GetHashCode();
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(Char)_value).GetTypeCode();
+    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(Char)_valueOrThrow).GetTypeCode();
 
     /// <inheritdoc/>
-    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(Char)_value).ToBoolean(provider);
+    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(Char)_valueOrThrow).ToBoolean(provider);
 
     /// <inheritdoc/>
-    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(Char)_value).ToByte(provider);
+    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(Char)_valueOrThrow).ToByte(provider);
 
     /// <inheritdoc/>
-    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(Char)_value).ToChar(provider);
+    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(Char)_valueOrThrow).ToChar(provider);
 
     /// <inheritdoc/>
-    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(Char)_value).ToDateTime(provider);
+    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(Char)_valueOrThrow).ToDateTime(provider);
 
     /// <inheritdoc/>
-    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(Char)_value).ToDecimal(provider);
+    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(Char)_valueOrThrow).ToDecimal(provider);
 
     /// <inheritdoc/>
-    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(Char)_value).ToDouble(provider);
+    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(Char)_valueOrThrow).ToDouble(provider);
 
     /// <inheritdoc/>
-    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(Char)_value).ToInt16(provider);
+    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(Char)_valueOrThrow).ToInt16(provider);
 
     /// <inheritdoc/>
-    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(Char)_value).ToInt32(provider);
+    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(Char)_valueOrThrow).ToInt32(provider);
 
     /// <inheritdoc/>
-    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(Char)_value).ToInt64(provider);
+    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(Char)_valueOrThrow).ToInt64(provider);
 
     /// <inheritdoc/>
-    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(Char)_value).ToSByte(provider);
+    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(Char)_valueOrThrow).ToSByte(provider);
 
     /// <inheritdoc/>
-    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(Char)_value).ToSingle(provider);
+    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(Char)_valueOrThrow).ToSingle(provider);
 
     /// <inheritdoc/>
-    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(Char)_value).ToString(provider);
+    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(Char)_valueOrThrow).ToString(provider);
 
     /// <inheritdoc/>
-    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(Char)_value).ToType(conversionType, provider);
+    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(Char)_valueOrThrow).ToType(conversionType, provider);
 
     /// <inheritdoc/>
-    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(Char)_value).ToUInt16(provider);
+    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(Char)_valueOrThrow).ToUInt16(provider);
 
     /// <inheritdoc/>
-    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(Char)_value).ToUInt32(provider);
+    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(Char)_valueOrThrow).ToUInt32(provider);
 
     /// <inheritdoc/>
-    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(Char)_value).ToUInt64(provider);
+    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(Char)_valueOrThrow).ToUInt64(provider);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override string ToString() => _value.ToString();
+    public override string ToString() => _valueOrThrow.ToString();
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.CharValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.CharValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
@@ -35,15 +35,13 @@ public static class SwaggerTypeHelper
         options.MapType<CharValue>(() => new OpenApiSchema
         {
             Type = "string",
-            Title = "CharValue",
-            Default = new OpenApiString(CharValue.Default.ToString())
+            Title = "CharValue"
         });
         options.MapType<CharValue?>(() => new OpenApiSchema
         {
             Type = "string",
             Nullable = true,
-            Title = "Nullable<CharValue>",
-            Default = new OpenApiString(CharValue.Default.ToString())
+            Title = "Nullable<CharValue>"
         });
     }
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.DateOnlyValue_GeneratesAllInterfacesAndConverters#DateOnlyValue.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.DateOnlyValue_GeneratesAllInterfacesAndConverters#DateOnlyValue.g.verified.cs
@@ -40,8 +40,11 @@ public readonly partial struct DateOnlyValue : IEquatable<DateOnlyValue>
     /// <inheritdoc/>
      public object GetUnderlyingPrimitiveValue() => (DateOnly)this;
 
+    private DateOnly _valueOrThrow => _isInitialized ? _value : throw new InvalidDomainValueException("The domain value has not been initialized");
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly DateOnly _value;
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly bool _isInitialized;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DateOnlyValue"/> class by validating the specified <see cref="DateOnly"/> value using <see cref="Validate"/> static method.
@@ -51,13 +54,13 @@ public readonly partial struct DateOnlyValue : IEquatable<DateOnlyValue>
     {
         Validate(value);
         _value = value;
+        _isInitialized = true;
     }
 
     /// <inheritdoc/>
     [Obsolete("Domain primitive cannot be created using empty Ctor", true)]
     public DateOnlyValue()
     {
-        _value = Default;
     }
 
     /// <inheritdoc/>
@@ -65,7 +68,7 @@ public readonly partial struct DateOnlyValue : IEquatable<DateOnlyValue>
     public override bool Equals(object? obj) => obj is DateOnlyValue other && Equals(other);
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Equals(DateOnlyValue other) => _value == other._value;
+    public bool Equals(DateOnlyValue other) => _valueOrThrow == other._valueOrThrow;
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator ==(DateOnlyValue left, DateOnlyValue right) => left.Equals(right);
@@ -86,7 +89,7 @@ public readonly partial struct DateOnlyValue : IEquatable<DateOnlyValue>
     }
 
     /// <inheritdoc/>
-    public int CompareTo(DateOnlyValue other) => _value.CompareTo(other._value);
+    public int CompareTo(DateOnlyValue other) => _valueOrThrow.CompareTo(other._valueOrThrow);
 
     /// <summary>
     /// Implicit conversion from <see cref = "DateOnly"/> to <see cref = "DateOnlyValue"/>
@@ -105,20 +108,20 @@ public readonly partial struct DateOnlyValue : IEquatable<DateOnlyValue>
     /// Implicit conversion from <see cref = "DateOnlyValue"/> to <see cref = "DateOnly"/>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator DateOnly(DateOnlyValue value) => (DateOnly)value._value;
+    public static implicit operator DateOnly(DateOnlyValue value) => (DateOnly)value._valueOrThrow;
 
     /// <summary>
     /// Implicit conversion from <see cref = "DateOnlyValue"/> (nullable) to <see cref = "DateOnly"/> (nullable)
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [return: NotNullIfNotNull(nameof(value))]
-    public static implicit operator DateOnly?(DateOnlyValue? value) => value is null ? null : (DateOnly?)value.Value._value;
+    public static implicit operator DateOnly?(DateOnlyValue? value) => value is null ? null : (DateOnly?)value.Value._valueOrThrow;
 
     /// <summary>
     /// Implicit conversion from <see cref = "DateOnlyValue"/> to <see cref = "DateTime"/>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator DateTime(DateOnlyValue value) => ((DateOnly)value._value).ToDateTime();
+    public static implicit operator DateTime(DateOnlyValue value) => ((DateOnly)value._valueOrThrow).ToDateTime();
 
     /// <summary>
     /// Implicit conversion from <see cref = "DateTime"/> to <see cref = "DateOnlyValue"/>
@@ -128,19 +131,19 @@ public readonly partial struct DateOnlyValue : IEquatable<DateOnlyValue>
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <(DateOnlyValue left, DateOnlyValue right) => left._value < right._value;
+    public static bool operator <(DateOnlyValue left, DateOnlyValue right) => left._valueOrThrow < right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <=(DateOnlyValue left, DateOnlyValue right) => left._value <= right._value;
+    public static bool operator <=(DateOnlyValue left, DateOnlyValue right) => left._valueOrThrow <= right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >(DateOnlyValue left, DateOnlyValue right) => left._value > right._value;
+    public static bool operator >(DateOnlyValue left, DateOnlyValue right) => left._valueOrThrow > right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >=(DateOnlyValue left, DateOnlyValue right) => left._value >= right._value;
+    public static bool operator >=(DateOnlyValue left, DateOnlyValue right) => left._valueOrThrow >= right._valueOrThrow;
 
 
     /// <inheritdoc/>
@@ -171,13 +174,13 @@ public readonly partial struct DateOnlyValue : IEquatable<DateOnlyValue>
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public string ToString(string? format, IFormatProvider? formatProvider) => _value.ToString(format, formatProvider);
+    public string ToString(string? format, IFormatProvider? formatProvider) => _valueOrThrow.ToString(format, formatProvider);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
     {
-        return ((ISpanFormattable)_value).TryFormat(destination, out charsWritten, format, provider);
+        return ((ISpanFormattable)_valueOrThrow).TryFormat(destination, out charsWritten, format, provider);
     }
 
 
@@ -186,67 +189,67 @@ public readonly partial struct DateOnlyValue : IEquatable<DateOnlyValue>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
     {
-        return ((IUtf8SpanFormattable)_value).TryFormat(utf8Destination, out bytesWritten, format, provider);
+        return ((IUtf8SpanFormattable)_valueOrThrow).TryFormat(utf8Destination, out bytesWritten, format, provider);
     }
 #endif
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override int GetHashCode() => _value.GetHashCode();
+    public override int GetHashCode() => _valueOrThrow.GetHashCode();
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    TypeCode IConvertible.GetTypeCode() => ((IConvertible)((DateOnly)_value).ToDateTime()).GetTypeCode();
+    TypeCode IConvertible.GetTypeCode() => ((IConvertible)((DateOnly)_valueOrThrow).ToDateTime()).GetTypeCode();
 
     /// <inheritdoc/>
-    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)((DateOnly)_value).ToDateTime()).ToBoolean(provider);
+    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)((DateOnly)_valueOrThrow).ToDateTime()).ToBoolean(provider);
 
     /// <inheritdoc/>
-    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)((DateOnly)_value).ToDateTime()).ToByte(provider);
+    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)((DateOnly)_valueOrThrow).ToDateTime()).ToByte(provider);
 
     /// <inheritdoc/>
-    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)((DateOnly)_value).ToDateTime()).ToChar(provider);
+    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)((DateOnly)_valueOrThrow).ToDateTime()).ToChar(provider);
 
     /// <inheritdoc/>
-    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)((DateOnly)_value).ToDateTime()).ToDateTime(provider);
+    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)((DateOnly)_valueOrThrow).ToDateTime()).ToDateTime(provider);
 
     /// <inheritdoc/>
-    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)((DateOnly)_value).ToDateTime()).ToDecimal(provider);
+    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)((DateOnly)_valueOrThrow).ToDateTime()).ToDecimal(provider);
 
     /// <inheritdoc/>
-    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)((DateOnly)_value).ToDateTime()).ToDouble(provider);
+    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)((DateOnly)_valueOrThrow).ToDateTime()).ToDouble(provider);
 
     /// <inheritdoc/>
-    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)((DateOnly)_value).ToDateTime()).ToInt16(provider);
+    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)((DateOnly)_valueOrThrow).ToDateTime()).ToInt16(provider);
 
     /// <inheritdoc/>
-    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)((DateOnly)_value).ToDateTime()).ToInt32(provider);
+    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)((DateOnly)_valueOrThrow).ToDateTime()).ToInt32(provider);
 
     /// <inheritdoc/>
-    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)((DateOnly)_value).ToDateTime()).ToInt64(provider);
+    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)((DateOnly)_valueOrThrow).ToDateTime()).ToInt64(provider);
 
     /// <inheritdoc/>
-    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)((DateOnly)_value).ToDateTime()).ToSByte(provider);
+    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)((DateOnly)_valueOrThrow).ToDateTime()).ToSByte(provider);
 
     /// <inheritdoc/>
-    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)((DateOnly)_value).ToDateTime()).ToSingle(provider);
+    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)((DateOnly)_valueOrThrow).ToDateTime()).ToSingle(provider);
 
     /// <inheritdoc/>
-    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)((DateOnly)_value).ToDateTime()).ToString(provider);
+    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)((DateOnly)_valueOrThrow).ToDateTime()).ToString(provider);
 
     /// <inheritdoc/>
-    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)((DateOnly)_value).ToDateTime()).ToType(conversionType, provider);
+    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)((DateOnly)_valueOrThrow).ToDateTime()).ToType(conversionType, provider);
 
     /// <inheritdoc/>
-    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)((DateOnly)_value).ToDateTime()).ToUInt16(provider);
+    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)((DateOnly)_valueOrThrow).ToDateTime()).ToUInt16(provider);
 
     /// <inheritdoc/>
-    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)((DateOnly)_value).ToDateTime()).ToUInt32(provider);
+    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)((DateOnly)_valueOrThrow).ToDateTime()).ToUInt32(provider);
 
     /// <inheritdoc/>
-    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)((DateOnly)_value).ToDateTime()).ToUInt64(provider);
+    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)((DateOnly)_valueOrThrow).ToDateTime()).ToUInt64(provider);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override string ToString() => _value.ToString();
+    public override string ToString() => _valueOrThrow.ToString();
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.DateOnlyValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.DateOnlyValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
@@ -36,16 +36,14 @@ public static class SwaggerTypeHelper
         {
             Type = "date",
             Format = "yyyy-MM-dd",
-            Title = "DateOnlyValue",
-            Default = new OpenApiString(DateOnlyValue.Default.ToString("YYYY-MM-DD", null))
+            Title = "DateOnlyValue"
         });
         options.MapType<DateOnlyValue?>(() => new OpenApiSchema
         {
             Type = "date",
             Format = "yyyy-MM-dd",
             Nullable = true,
-            Title = "Nullable<DateOnlyValue>",
-            Default = new OpenApiString(DateOnlyValue.Default.ToString("YYYY-MM-DD", null))
+            Title = "Nullable<DateOnlyValue>"
         });
     }
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.DateTimeOffsetValue_GeneratesAllInterfacesAndConverters#DateTimeOffsetValue.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.DateTimeOffsetValue_GeneratesAllInterfacesAndConverters#DateTimeOffsetValue.g.verified.cs
@@ -40,8 +40,11 @@ public readonly partial struct DateTimeOffsetValue : IEquatable<DateTimeOffsetVa
     /// <inheritdoc/>
      public object GetUnderlyingPrimitiveValue() => (DateTimeOffset)this;
 
+    private DateTimeOffset _valueOrThrow => _isInitialized ? _value : throw new InvalidDomainValueException("The domain value has not been initialized");
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly DateTimeOffset _value;
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly bool _isInitialized;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DateTimeOffsetValue"/> class by validating the specified <see cref="DateTimeOffset"/> value using <see cref="Validate"/> static method.
@@ -51,13 +54,13 @@ public readonly partial struct DateTimeOffsetValue : IEquatable<DateTimeOffsetVa
     {
         Validate(value);
         _value = value;
+        _isInitialized = true;
     }
 
     /// <inheritdoc/>
     [Obsolete("Domain primitive cannot be created using empty Ctor", true)]
     public DateTimeOffsetValue()
     {
-        _value = Default;
     }
 
     /// <inheritdoc/>
@@ -65,7 +68,7 @@ public readonly partial struct DateTimeOffsetValue : IEquatable<DateTimeOffsetVa
     public override bool Equals(object? obj) => obj is DateTimeOffsetValue other && Equals(other);
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Equals(DateTimeOffsetValue other) => _value == other._value;
+    public bool Equals(DateTimeOffsetValue other) => _valueOrThrow == other._valueOrThrow;
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator ==(DateTimeOffsetValue left, DateTimeOffsetValue right) => left.Equals(right);
@@ -86,7 +89,7 @@ public readonly partial struct DateTimeOffsetValue : IEquatable<DateTimeOffsetVa
     }
 
     /// <inheritdoc/>
-    public int CompareTo(DateTimeOffsetValue other) => _value.CompareTo(other._value);
+    public int CompareTo(DateTimeOffsetValue other) => _valueOrThrow.CompareTo(other._valueOrThrow);
 
     /// <summary>
     /// Implicit conversion from <see cref = "DateTimeOffset"/> to <see cref = "DateTimeOffsetValue"/>
@@ -105,30 +108,30 @@ public readonly partial struct DateTimeOffsetValue : IEquatable<DateTimeOffsetVa
     /// Implicit conversion from <see cref = "DateTimeOffsetValue"/> to <see cref = "DateTimeOffset"/>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator DateTimeOffset(DateTimeOffsetValue value) => (DateTimeOffset)value._value;
+    public static implicit operator DateTimeOffset(DateTimeOffsetValue value) => (DateTimeOffset)value._valueOrThrow;
 
     /// <summary>
     /// Implicit conversion from <see cref = "DateTimeOffsetValue"/> (nullable) to <see cref = "DateTimeOffset"/> (nullable)
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [return: NotNullIfNotNull(nameof(value))]
-    public static implicit operator DateTimeOffset?(DateTimeOffsetValue? value) => value is null ? null : (DateTimeOffset?)value.Value._value;
+    public static implicit operator DateTimeOffset?(DateTimeOffsetValue? value) => value is null ? null : (DateTimeOffset?)value.Value._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <(DateTimeOffsetValue left, DateTimeOffsetValue right) => left._value < right._value;
+    public static bool operator <(DateTimeOffsetValue left, DateTimeOffsetValue right) => left._valueOrThrow < right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <=(DateTimeOffsetValue left, DateTimeOffsetValue right) => left._value <= right._value;
+    public static bool operator <=(DateTimeOffsetValue left, DateTimeOffsetValue right) => left._valueOrThrow <= right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >(DateTimeOffsetValue left, DateTimeOffsetValue right) => left._value > right._value;
+    public static bool operator >(DateTimeOffsetValue left, DateTimeOffsetValue right) => left._valueOrThrow > right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >=(DateTimeOffsetValue left, DateTimeOffsetValue right) => left._value >= right._value;
+    public static bool operator >=(DateTimeOffsetValue left, DateTimeOffsetValue right) => left._valueOrThrow >= right._valueOrThrow;
 
 
     /// <inheritdoc/>
@@ -159,13 +162,13 @@ public readonly partial struct DateTimeOffsetValue : IEquatable<DateTimeOffsetVa
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public string ToString(string? format, IFormatProvider? formatProvider) => _value.ToString(format, formatProvider);
+    public string ToString(string? format, IFormatProvider? formatProvider) => _valueOrThrow.ToString(format, formatProvider);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
     {
-        return ((ISpanFormattable)_value).TryFormat(destination, out charsWritten, format, provider);
+        return ((ISpanFormattable)_valueOrThrow).TryFormat(destination, out charsWritten, format, provider);
     }
 
 
@@ -174,67 +177,67 @@ public readonly partial struct DateTimeOffsetValue : IEquatable<DateTimeOffsetVa
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
     {
-        return ((IUtf8SpanFormattable)_value).TryFormat(utf8Destination, out bytesWritten, format, provider);
+        return ((IUtf8SpanFormattable)_valueOrThrow).TryFormat(utf8Destination, out bytesWritten, format, provider);
     }
 #endif
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override int GetHashCode() => _value.GetHashCode();
+    public override int GetHashCode() => _valueOrThrow.GetHashCode();
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(DateTimeOffset)_value).GetTypeCode();
+    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(DateTimeOffset)_valueOrThrow).GetTypeCode();
 
     /// <inheritdoc/>
-    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_value).ToBoolean(provider);
+    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_valueOrThrow).ToBoolean(provider);
 
     /// <inheritdoc/>
-    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_value).ToByte(provider);
+    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_valueOrThrow).ToByte(provider);
 
     /// <inheritdoc/>
-    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_value).ToChar(provider);
+    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_valueOrThrow).ToChar(provider);
 
     /// <inheritdoc/>
-    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_value).ToDateTime(provider);
+    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_valueOrThrow).ToDateTime(provider);
 
     /// <inheritdoc/>
-    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_value).ToDecimal(provider);
+    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_valueOrThrow).ToDecimal(provider);
 
     /// <inheritdoc/>
-    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_value).ToDouble(provider);
+    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_valueOrThrow).ToDouble(provider);
 
     /// <inheritdoc/>
-    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_value).ToInt16(provider);
+    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_valueOrThrow).ToInt16(provider);
 
     /// <inheritdoc/>
-    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_value).ToInt32(provider);
+    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_valueOrThrow).ToInt32(provider);
 
     /// <inheritdoc/>
-    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_value).ToInt64(provider);
+    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_valueOrThrow).ToInt64(provider);
 
     /// <inheritdoc/>
-    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_value).ToSByte(provider);
+    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_valueOrThrow).ToSByte(provider);
 
     /// <inheritdoc/>
-    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_value).ToSingle(provider);
+    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_valueOrThrow).ToSingle(provider);
 
     /// <inheritdoc/>
-    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_value).ToString(provider);
+    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_valueOrThrow).ToString(provider);
 
     /// <inheritdoc/>
-    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_value).ToType(conversionType, provider);
+    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_valueOrThrow).ToType(conversionType, provider);
 
     /// <inheritdoc/>
-    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_value).ToUInt16(provider);
+    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_valueOrThrow).ToUInt16(provider);
 
     /// <inheritdoc/>
-    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_value).ToUInt32(provider);
+    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_valueOrThrow).ToUInt32(provider);
 
     /// <inheritdoc/>
-    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_value).ToUInt64(provider);
+    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(DateTimeOffset)_valueOrThrow).ToUInt64(provider);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override string ToString() => _value.ToString();
+    public override string ToString() => _valueOrThrow.ToString();
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.DateTimeOffsetValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.DateTimeOffsetValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
@@ -36,16 +36,14 @@ public static class SwaggerTypeHelper
         {
             Type = "string",
             Format = "date-time",
-            Title = "DateTimeOffsetValue",
-            Default = new OpenApiDateTime(((DateTimeOffset)DateTimeOffsetValue.Default).DateTime)
+            Title = "DateTimeOffsetValue"
         });
         options.MapType<DateTimeOffsetValue?>(() => new OpenApiSchema
         {
             Type = "string",
             Format = "date-time",
             Nullable = true,
-            Title = "Nullable<DateTimeOffsetValue>",
-            Default = new OpenApiDateTime(((DateTimeOffset)DateTimeOffsetValue.Default).DateTime)
+            Title = "Nullable<DateTimeOffsetValue>"
         });
     }
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.DateTimeValue_GeneratesAllInterfacesAndConverters#DateTimeValue.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.DateTimeValue_GeneratesAllInterfacesAndConverters#DateTimeValue.g.verified.cs
@@ -40,8 +40,11 @@ public readonly partial struct DateTimeValue : IEquatable<DateTimeValue>
     /// <inheritdoc/>
      public object GetUnderlyingPrimitiveValue() => (DateTime)this;
 
+    private DateTime _valueOrThrow => _isInitialized ? _value : throw new InvalidDomainValueException("The domain value has not been initialized");
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly DateTime _value;
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly bool _isInitialized;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DateTimeValue"/> class by validating the specified <see cref="DateTime"/> value using <see cref="Validate"/> static method.
@@ -51,13 +54,13 @@ public readonly partial struct DateTimeValue : IEquatable<DateTimeValue>
     {
         Validate(value);
         _value = value;
+        _isInitialized = true;
     }
 
     /// <inheritdoc/>
     [Obsolete("Domain primitive cannot be created using empty Ctor", true)]
     public DateTimeValue()
     {
-        _value = Default;
     }
 
     /// <inheritdoc/>
@@ -65,7 +68,7 @@ public readonly partial struct DateTimeValue : IEquatable<DateTimeValue>
     public override bool Equals(object? obj) => obj is DateTimeValue other && Equals(other);
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Equals(DateTimeValue other) => _value == other._value;
+    public bool Equals(DateTimeValue other) => _valueOrThrow == other._valueOrThrow;
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator ==(DateTimeValue left, DateTimeValue right) => left.Equals(right);
@@ -86,7 +89,7 @@ public readonly partial struct DateTimeValue : IEquatable<DateTimeValue>
     }
 
     /// <inheritdoc/>
-    public int CompareTo(DateTimeValue other) => _value.CompareTo(other._value);
+    public int CompareTo(DateTimeValue other) => _valueOrThrow.CompareTo(other._valueOrThrow);
 
     /// <summary>
     /// Implicit conversion from <see cref = "DateTime"/> to <see cref = "DateTimeValue"/>
@@ -105,30 +108,30 @@ public readonly partial struct DateTimeValue : IEquatable<DateTimeValue>
     /// Implicit conversion from <see cref = "DateTimeValue"/> to <see cref = "DateTime"/>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator DateTime(DateTimeValue value) => (DateTime)value._value;
+    public static implicit operator DateTime(DateTimeValue value) => (DateTime)value._valueOrThrow;
 
     /// <summary>
     /// Implicit conversion from <see cref = "DateTimeValue"/> (nullable) to <see cref = "DateTime"/> (nullable)
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [return: NotNullIfNotNull(nameof(value))]
-    public static implicit operator DateTime?(DateTimeValue? value) => value is null ? null : (DateTime?)value.Value._value;
+    public static implicit operator DateTime?(DateTimeValue? value) => value is null ? null : (DateTime?)value.Value._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <(DateTimeValue left, DateTimeValue right) => left._value < right._value;
+    public static bool operator <(DateTimeValue left, DateTimeValue right) => left._valueOrThrow < right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <=(DateTimeValue left, DateTimeValue right) => left._value <= right._value;
+    public static bool operator <=(DateTimeValue left, DateTimeValue right) => left._valueOrThrow <= right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >(DateTimeValue left, DateTimeValue right) => left._value > right._value;
+    public static bool operator >(DateTimeValue left, DateTimeValue right) => left._valueOrThrow > right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >=(DateTimeValue left, DateTimeValue right) => left._value >= right._value;
+    public static bool operator >=(DateTimeValue left, DateTimeValue right) => left._valueOrThrow >= right._valueOrThrow;
 
 
     /// <inheritdoc/>
@@ -159,13 +162,13 @@ public readonly partial struct DateTimeValue : IEquatable<DateTimeValue>
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public string ToString(string? format, IFormatProvider? formatProvider) => _value.ToString(format, formatProvider);
+    public string ToString(string? format, IFormatProvider? formatProvider) => _valueOrThrow.ToString(format, formatProvider);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
     {
-        return ((ISpanFormattable)_value).TryFormat(destination, out charsWritten, format, provider);
+        return ((ISpanFormattable)_valueOrThrow).TryFormat(destination, out charsWritten, format, provider);
     }
 
 
@@ -174,67 +177,67 @@ public readonly partial struct DateTimeValue : IEquatable<DateTimeValue>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
     {
-        return ((IUtf8SpanFormattable)_value).TryFormat(utf8Destination, out bytesWritten, format, provider);
+        return ((IUtf8SpanFormattable)_valueOrThrow).TryFormat(utf8Destination, out bytesWritten, format, provider);
     }
 #endif
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override int GetHashCode() => _value.GetHashCode();
+    public override int GetHashCode() => _valueOrThrow.GetHashCode();
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(DateTime)_value).GetTypeCode();
+    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(DateTime)_valueOrThrow).GetTypeCode();
 
     /// <inheritdoc/>
-    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(DateTime)_value).ToBoolean(provider);
+    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(DateTime)_valueOrThrow).ToBoolean(provider);
 
     /// <inheritdoc/>
-    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(DateTime)_value).ToByte(provider);
+    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(DateTime)_valueOrThrow).ToByte(provider);
 
     /// <inheritdoc/>
-    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(DateTime)_value).ToChar(provider);
+    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(DateTime)_valueOrThrow).ToChar(provider);
 
     /// <inheritdoc/>
-    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(DateTime)_value).ToDateTime(provider);
+    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(DateTime)_valueOrThrow).ToDateTime(provider);
 
     /// <inheritdoc/>
-    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(DateTime)_value).ToDecimal(provider);
+    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(DateTime)_valueOrThrow).ToDecimal(provider);
 
     /// <inheritdoc/>
-    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(DateTime)_value).ToDouble(provider);
+    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(DateTime)_valueOrThrow).ToDouble(provider);
 
     /// <inheritdoc/>
-    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(DateTime)_value).ToInt16(provider);
+    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(DateTime)_valueOrThrow).ToInt16(provider);
 
     /// <inheritdoc/>
-    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(DateTime)_value).ToInt32(provider);
+    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(DateTime)_valueOrThrow).ToInt32(provider);
 
     /// <inheritdoc/>
-    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(DateTime)_value).ToInt64(provider);
+    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(DateTime)_valueOrThrow).ToInt64(provider);
 
     /// <inheritdoc/>
-    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(DateTime)_value).ToSByte(provider);
+    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(DateTime)_valueOrThrow).ToSByte(provider);
 
     /// <inheritdoc/>
-    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(DateTime)_value).ToSingle(provider);
+    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(DateTime)_valueOrThrow).ToSingle(provider);
 
     /// <inheritdoc/>
-    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(DateTime)_value).ToString(provider);
+    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(DateTime)_valueOrThrow).ToString(provider);
 
     /// <inheritdoc/>
-    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(DateTime)_value).ToType(conversionType, provider);
+    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(DateTime)_valueOrThrow).ToType(conversionType, provider);
 
     /// <inheritdoc/>
-    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(DateTime)_value).ToUInt16(provider);
+    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(DateTime)_valueOrThrow).ToUInt16(provider);
 
     /// <inheritdoc/>
-    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(DateTime)_value).ToUInt32(provider);
+    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(DateTime)_valueOrThrow).ToUInt32(provider);
 
     /// <inheritdoc/>
-    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(DateTime)_value).ToUInt64(provider);
+    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(DateTime)_valueOrThrow).ToUInt64(provider);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override string ToString() => _value.ToString();
+    public override string ToString() => _valueOrThrow.ToString();
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.DateTimeValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.DateTimeValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
@@ -36,16 +36,14 @@ public static class SwaggerTypeHelper
         {
             Type = "string",
             Format = "date-time",
-            Title = "DateTimeValue",
-            Default = new OpenApiDateTime(DateTimeValue.Default)
+            Title = "DateTimeValue"
         });
         options.MapType<DateTimeValue?>(() => new OpenApiSchema
         {
             Type = "string",
             Format = "date-time",
             Nullable = true,
-            Title = "Nullable<DateTimeValue>",
-            Default = new OpenApiDateTime(DateTimeValue.Default)
+            Title = "Nullable<DateTimeValue>"
         });
     }
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.DecimalValue_GeneratesAllInterfacesAndConverters#DecimalValue.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.DecimalValue_GeneratesAllInterfacesAndConverters#DecimalValue.g.verified.cs
@@ -44,8 +44,11 @@ public readonly partial struct DecimalValue : IEquatable<DecimalValue>
     /// <inheritdoc/>
      public object GetUnderlyingPrimitiveValue() => (decimal)this;
 
+    private decimal _valueOrThrow => _isInitialized ? _value : throw new InvalidDomainValueException("The domain value has not been initialized");
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly decimal _value;
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly bool _isInitialized;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DecimalValue"/> class by validating the specified <see cref="decimal"/> value using <see cref="Validate"/> static method.
@@ -55,13 +58,13 @@ public readonly partial struct DecimalValue : IEquatable<DecimalValue>
     {
         Validate(value);
         _value = value;
+        _isInitialized = true;
     }
 
     /// <inheritdoc/>
     [Obsolete("Domain primitive cannot be created using empty Ctor", true)]
     public DecimalValue()
     {
-        _value = Default;
     }
 
     /// <inheritdoc/>
@@ -69,7 +72,7 @@ public readonly partial struct DecimalValue : IEquatable<DecimalValue>
     public override bool Equals(object? obj) => obj is DecimalValue other && Equals(other);
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Equals(DecimalValue other) => _value == other._value;
+    public bool Equals(DecimalValue other) => _valueOrThrow == other._valueOrThrow;
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator ==(DecimalValue left, DecimalValue right) => left.Equals(right);
@@ -90,7 +93,7 @@ public readonly partial struct DecimalValue : IEquatable<DecimalValue>
     }
 
     /// <inheritdoc/>
-    public int CompareTo(DecimalValue other) => _value.CompareTo(other._value);
+    public int CompareTo(DecimalValue other) => _valueOrThrow.CompareTo(other._valueOrThrow);
 
     /// <summary>
     /// Implicit conversion from <see cref = "decimal"/> to <see cref = "DecimalValue"/>
@@ -109,50 +112,50 @@ public readonly partial struct DecimalValue : IEquatable<DecimalValue>
     /// Implicit conversion from <see cref = "DecimalValue"/> to <see cref = "decimal"/>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator decimal(DecimalValue value) => (decimal)value._value;
+    public static implicit operator decimal(DecimalValue value) => (decimal)value._valueOrThrow;
 
     /// <summary>
     /// Implicit conversion from <see cref = "DecimalValue"/> (nullable) to <see cref = "decimal"/> (nullable)
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [return: NotNullIfNotNull(nameof(value))]
-    public static implicit operator decimal?(DecimalValue? value) => value is null ? null : (decimal?)value.Value._value;
+    public static implicit operator decimal?(DecimalValue? value) => value is null ? null : (decimal?)value.Value._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static DecimalValue operator +(DecimalValue left, DecimalValue right) => new(left._value + right._value);
+    public static DecimalValue operator +(DecimalValue left, DecimalValue right) => new(left._valueOrThrow + right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static DecimalValue operator -(DecimalValue left, DecimalValue right) => new(left._value - right._value);
+    public static DecimalValue operator -(DecimalValue left, DecimalValue right) => new(left._valueOrThrow - right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static DecimalValue operator *(DecimalValue left, DecimalValue right) => new(left._value * right._value);
+    public static DecimalValue operator *(DecimalValue left, DecimalValue right) => new(left._valueOrThrow * right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static DecimalValue operator /(DecimalValue left, DecimalValue right) => new(left._value / right._value);
+    public static DecimalValue operator /(DecimalValue left, DecimalValue right) => new(left._valueOrThrow / right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static DecimalValue operator %(DecimalValue left, DecimalValue right) => new(left._value % right._value);
+    public static DecimalValue operator %(DecimalValue left, DecimalValue right) => new(left._valueOrThrow % right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <(DecimalValue left, DecimalValue right) => left._value < right._value;
+    public static bool operator <(DecimalValue left, DecimalValue right) => left._valueOrThrow < right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <=(DecimalValue left, DecimalValue right) => left._value <= right._value;
+    public static bool operator <=(DecimalValue left, DecimalValue right) => left._valueOrThrow <= right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >(DecimalValue left, DecimalValue right) => left._value > right._value;
+    public static bool operator >(DecimalValue left, DecimalValue right) => left._valueOrThrow > right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >=(DecimalValue left, DecimalValue right) => left._value >= right._value;
+    public static bool operator >=(DecimalValue left, DecimalValue right) => left._valueOrThrow >= right._valueOrThrow;
 
 
     /// <inheritdoc/>
@@ -186,67 +189,67 @@ public readonly partial struct DecimalValue : IEquatable<DecimalValue>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
     {
-        return ((IUtf8SpanFormattable)_value).TryFormat(utf8Destination, out bytesWritten, format, provider);
+        return ((IUtf8SpanFormattable)_valueOrThrow).TryFormat(utf8Destination, out bytesWritten, format, provider);
     }
 #endif
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override int GetHashCode() => _value.GetHashCode();
+    public override int GetHashCode() => _valueOrThrow.GetHashCode();
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(Decimal)_value).GetTypeCode();
+    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(Decimal)_valueOrThrow).GetTypeCode();
 
     /// <inheritdoc/>
-    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(Decimal)_value).ToBoolean(provider);
+    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(Decimal)_valueOrThrow).ToBoolean(provider);
 
     /// <inheritdoc/>
-    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(Decimal)_value).ToByte(provider);
+    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(Decimal)_valueOrThrow).ToByte(provider);
 
     /// <inheritdoc/>
-    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(Decimal)_value).ToChar(provider);
+    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(Decimal)_valueOrThrow).ToChar(provider);
 
     /// <inheritdoc/>
-    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(Decimal)_value).ToDateTime(provider);
+    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(Decimal)_valueOrThrow).ToDateTime(provider);
 
     /// <inheritdoc/>
-    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(Decimal)_value).ToDecimal(provider);
+    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(Decimal)_valueOrThrow).ToDecimal(provider);
 
     /// <inheritdoc/>
-    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(Decimal)_value).ToDouble(provider);
+    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(Decimal)_valueOrThrow).ToDouble(provider);
 
     /// <inheritdoc/>
-    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(Decimal)_value).ToInt16(provider);
+    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(Decimal)_valueOrThrow).ToInt16(provider);
 
     /// <inheritdoc/>
-    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(Decimal)_value).ToInt32(provider);
+    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(Decimal)_valueOrThrow).ToInt32(provider);
 
     /// <inheritdoc/>
-    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(Decimal)_value).ToInt64(provider);
+    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(Decimal)_valueOrThrow).ToInt64(provider);
 
     /// <inheritdoc/>
-    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(Decimal)_value).ToSByte(provider);
+    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(Decimal)_valueOrThrow).ToSByte(provider);
 
     /// <inheritdoc/>
-    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(Decimal)_value).ToSingle(provider);
+    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(Decimal)_valueOrThrow).ToSingle(provider);
 
     /// <inheritdoc/>
-    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(Decimal)_value).ToString(provider);
+    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(Decimal)_valueOrThrow).ToString(provider);
 
     /// <inheritdoc/>
-    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(Decimal)_value).ToType(conversionType, provider);
+    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(Decimal)_valueOrThrow).ToType(conversionType, provider);
 
     /// <inheritdoc/>
-    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(Decimal)_value).ToUInt16(provider);
+    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(Decimal)_valueOrThrow).ToUInt16(provider);
 
     /// <inheritdoc/>
-    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(Decimal)_value).ToUInt32(provider);
+    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(Decimal)_valueOrThrow).ToUInt32(provider);
 
     /// <inheritdoc/>
-    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(Decimal)_value).ToUInt64(provider);
+    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(Decimal)_valueOrThrow).ToUInt64(provider);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override string ToString() => _value.ToString();
+    public override string ToString() => _valueOrThrow.ToString();
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.DecimalValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.DecimalValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
@@ -36,16 +36,14 @@ public static class SwaggerTypeHelper
         {
             Type = "number",
             Format = "decimal",
-            Title = "DecimalValue",
-            Default = new OpenApiDouble(decimal.ToDouble(DecimalValue.Default))
+            Title = "DecimalValue"
         });
         options.MapType<DecimalValue?>(() => new OpenApiSchema
         {
             Type = "number",
             Format = "decimal",
             Nullable = true,
-            Title = "Nullable<DecimalValue>",
-            Default = new OpenApiDouble(decimal.ToDouble(DecimalValue.Default))
+            Title = "Nullable<DecimalValue>"
         });
     }
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.DoubleValue_GeneratesAllInterfacesAndConverters#DoubleValue.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.DoubleValue_GeneratesAllInterfacesAndConverters#DoubleValue.g.verified.cs
@@ -44,8 +44,11 @@ public readonly partial struct DoubleValue : IEquatable<DoubleValue>
     /// <inheritdoc/>
      public object GetUnderlyingPrimitiveValue() => (double)this;
 
+    private double _valueOrThrow => _isInitialized ? _value : throw new InvalidDomainValueException("The domain value has not been initialized");
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly double _value;
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly bool _isInitialized;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DoubleValue"/> class by validating the specified <see cref="double"/> value using <see cref="Validate"/> static method.
@@ -55,13 +58,13 @@ public readonly partial struct DoubleValue : IEquatable<DoubleValue>
     {
         Validate(value);
         _value = value;
+        _isInitialized = true;
     }
 
     /// <inheritdoc/>
     [Obsolete("Domain primitive cannot be created using empty Ctor", true)]
     public DoubleValue()
     {
-        _value = Default;
     }
 
     /// <inheritdoc/>
@@ -69,7 +72,7 @@ public readonly partial struct DoubleValue : IEquatable<DoubleValue>
     public override bool Equals(object? obj) => obj is DoubleValue other && Equals(other);
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Equals(DoubleValue other) => _value == other._value;
+    public bool Equals(DoubleValue other) => _valueOrThrow == other._valueOrThrow;
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator ==(DoubleValue left, DoubleValue right) => left.Equals(right);
@@ -90,7 +93,7 @@ public readonly partial struct DoubleValue : IEquatable<DoubleValue>
     }
 
     /// <inheritdoc/>
-    public int CompareTo(DoubleValue other) => _value.CompareTo(other._value);
+    public int CompareTo(DoubleValue other) => _valueOrThrow.CompareTo(other._valueOrThrow);
 
     /// <summary>
     /// Implicit conversion from <see cref = "double"/> to <see cref = "DoubleValue"/>
@@ -109,50 +112,50 @@ public readonly partial struct DoubleValue : IEquatable<DoubleValue>
     /// Implicit conversion from <see cref = "DoubleValue"/> to <see cref = "double"/>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator double(DoubleValue value) => (double)value._value;
+    public static implicit operator double(DoubleValue value) => (double)value._valueOrThrow;
 
     /// <summary>
     /// Implicit conversion from <see cref = "DoubleValue"/> (nullable) to <see cref = "double"/> (nullable)
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [return: NotNullIfNotNull(nameof(value))]
-    public static implicit operator double?(DoubleValue? value) => value is null ? null : (double?)value.Value._value;
+    public static implicit operator double?(DoubleValue? value) => value is null ? null : (double?)value.Value._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static DoubleValue operator +(DoubleValue left, DoubleValue right) => new(left._value + right._value);
+    public static DoubleValue operator +(DoubleValue left, DoubleValue right) => new(left._valueOrThrow + right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static DoubleValue operator -(DoubleValue left, DoubleValue right) => new(left._value - right._value);
+    public static DoubleValue operator -(DoubleValue left, DoubleValue right) => new(left._valueOrThrow - right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static DoubleValue operator *(DoubleValue left, DoubleValue right) => new(left._value * right._value);
+    public static DoubleValue operator *(DoubleValue left, DoubleValue right) => new(left._valueOrThrow * right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static DoubleValue operator /(DoubleValue left, DoubleValue right) => new(left._value / right._value);
+    public static DoubleValue operator /(DoubleValue left, DoubleValue right) => new(left._valueOrThrow / right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static DoubleValue operator %(DoubleValue left, DoubleValue right) => new(left._value % right._value);
+    public static DoubleValue operator %(DoubleValue left, DoubleValue right) => new(left._valueOrThrow % right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <(DoubleValue left, DoubleValue right) => left._value < right._value;
+    public static bool operator <(DoubleValue left, DoubleValue right) => left._valueOrThrow < right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <=(DoubleValue left, DoubleValue right) => left._value <= right._value;
+    public static bool operator <=(DoubleValue left, DoubleValue right) => left._valueOrThrow <= right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >(DoubleValue left, DoubleValue right) => left._value > right._value;
+    public static bool operator >(DoubleValue left, DoubleValue right) => left._valueOrThrow > right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >=(DoubleValue left, DoubleValue right) => left._value >= right._value;
+    public static bool operator >=(DoubleValue left, DoubleValue right) => left._valueOrThrow >= right._valueOrThrow;
 
 
     /// <inheritdoc/>
@@ -186,67 +189,67 @@ public readonly partial struct DoubleValue : IEquatable<DoubleValue>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
     {
-        return ((IUtf8SpanFormattable)_value).TryFormat(utf8Destination, out bytesWritten, format, provider);
+        return ((IUtf8SpanFormattable)_valueOrThrow).TryFormat(utf8Destination, out bytesWritten, format, provider);
     }
 #endif
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override int GetHashCode() => _value.GetHashCode();
+    public override int GetHashCode() => _valueOrThrow.GetHashCode();
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(Double)_value).GetTypeCode();
+    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(Double)_valueOrThrow).GetTypeCode();
 
     /// <inheritdoc/>
-    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(Double)_value).ToBoolean(provider);
+    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(Double)_valueOrThrow).ToBoolean(provider);
 
     /// <inheritdoc/>
-    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(Double)_value).ToByte(provider);
+    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(Double)_valueOrThrow).ToByte(provider);
 
     /// <inheritdoc/>
-    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(Double)_value).ToChar(provider);
+    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(Double)_valueOrThrow).ToChar(provider);
 
     /// <inheritdoc/>
-    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(Double)_value).ToDateTime(provider);
+    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(Double)_valueOrThrow).ToDateTime(provider);
 
     /// <inheritdoc/>
-    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(Double)_value).ToDecimal(provider);
+    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(Double)_valueOrThrow).ToDecimal(provider);
 
     /// <inheritdoc/>
-    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(Double)_value).ToDouble(provider);
+    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(Double)_valueOrThrow).ToDouble(provider);
 
     /// <inheritdoc/>
-    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(Double)_value).ToInt16(provider);
+    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(Double)_valueOrThrow).ToInt16(provider);
 
     /// <inheritdoc/>
-    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(Double)_value).ToInt32(provider);
+    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(Double)_valueOrThrow).ToInt32(provider);
 
     /// <inheritdoc/>
-    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(Double)_value).ToInt64(provider);
+    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(Double)_valueOrThrow).ToInt64(provider);
 
     /// <inheritdoc/>
-    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(Double)_value).ToSByte(provider);
+    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(Double)_valueOrThrow).ToSByte(provider);
 
     /// <inheritdoc/>
-    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(Double)_value).ToSingle(provider);
+    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(Double)_valueOrThrow).ToSingle(provider);
 
     /// <inheritdoc/>
-    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(Double)_value).ToString(provider);
+    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(Double)_valueOrThrow).ToString(provider);
 
     /// <inheritdoc/>
-    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(Double)_value).ToType(conversionType, provider);
+    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(Double)_valueOrThrow).ToType(conversionType, provider);
 
     /// <inheritdoc/>
-    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(Double)_value).ToUInt16(provider);
+    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(Double)_valueOrThrow).ToUInt16(provider);
 
     /// <inheritdoc/>
-    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(Double)_value).ToUInt32(provider);
+    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(Double)_valueOrThrow).ToUInt32(provider);
 
     /// <inheritdoc/>
-    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(Double)_value).ToUInt64(provider);
+    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(Double)_valueOrThrow).ToUInt64(provider);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override string ToString() => _value.ToString();
+    public override string ToString() => _valueOrThrow.ToString();
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.DoubleValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.DoubleValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
@@ -36,16 +36,14 @@ public static class SwaggerTypeHelper
         {
             Type = "number",
             Format = "double",
-            Title = "DoubleValue",
-            Default = new OpenApiDouble(DoubleValue.Default)
+            Title = "DoubleValue"
         });
         options.MapType<DoubleValue?>(() => new OpenApiSchema
         {
             Type = "number",
             Format = "double",
             Nullable = true,
-            Title = "Nullable<DoubleValue>",
-            Default = new OpenApiDouble(DoubleValue.Default)
+            Title = "Nullable<DoubleValue>"
         });
     }
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.FloatValue_GeneratesAllInterfacesAndConverters#FloatValue.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.FloatValue_GeneratesAllInterfacesAndConverters#FloatValue.g.verified.cs
@@ -44,8 +44,11 @@ public readonly partial struct FloatValue : IEquatable<FloatValue>
     /// <inheritdoc/>
      public object GetUnderlyingPrimitiveValue() => (float)this;
 
+    private float _valueOrThrow => _isInitialized ? _value : throw new InvalidDomainValueException("The domain value has not been initialized");
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly float _value;
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly bool _isInitialized;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FloatValue"/> class by validating the specified <see cref="float"/> value using <see cref="Validate"/> static method.
@@ -55,13 +58,13 @@ public readonly partial struct FloatValue : IEquatable<FloatValue>
     {
         Validate(value);
         _value = value;
+        _isInitialized = true;
     }
 
     /// <inheritdoc/>
     [Obsolete("Domain primitive cannot be created using empty Ctor", true)]
     public FloatValue()
     {
-        _value = Default;
     }
 
     /// <inheritdoc/>
@@ -69,7 +72,7 @@ public readonly partial struct FloatValue : IEquatable<FloatValue>
     public override bool Equals(object? obj) => obj is FloatValue other && Equals(other);
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Equals(FloatValue other) => _value == other._value;
+    public bool Equals(FloatValue other) => _valueOrThrow == other._valueOrThrow;
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator ==(FloatValue left, FloatValue right) => left.Equals(right);
@@ -90,7 +93,7 @@ public readonly partial struct FloatValue : IEquatable<FloatValue>
     }
 
     /// <inheritdoc/>
-    public int CompareTo(FloatValue other) => _value.CompareTo(other._value);
+    public int CompareTo(FloatValue other) => _valueOrThrow.CompareTo(other._valueOrThrow);
 
     /// <summary>
     /// Implicit conversion from <see cref = "float"/> to <see cref = "FloatValue"/>
@@ -109,50 +112,50 @@ public readonly partial struct FloatValue : IEquatable<FloatValue>
     /// Implicit conversion from <see cref = "FloatValue"/> to <see cref = "float"/>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator float(FloatValue value) => (float)value._value;
+    public static implicit operator float(FloatValue value) => (float)value._valueOrThrow;
 
     /// <summary>
     /// Implicit conversion from <see cref = "FloatValue"/> (nullable) to <see cref = "float"/> (nullable)
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [return: NotNullIfNotNull(nameof(value))]
-    public static implicit operator float?(FloatValue? value) => value is null ? null : (float?)value.Value._value;
+    public static implicit operator float?(FloatValue? value) => value is null ? null : (float?)value.Value._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static FloatValue operator +(FloatValue left, FloatValue right) => new(left._value + right._value);
+    public static FloatValue operator +(FloatValue left, FloatValue right) => new(left._valueOrThrow + right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static FloatValue operator -(FloatValue left, FloatValue right) => new(left._value - right._value);
+    public static FloatValue operator -(FloatValue left, FloatValue right) => new(left._valueOrThrow - right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static FloatValue operator *(FloatValue left, FloatValue right) => new(left._value * right._value);
+    public static FloatValue operator *(FloatValue left, FloatValue right) => new(left._valueOrThrow * right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static FloatValue operator /(FloatValue left, FloatValue right) => new(left._value / right._value);
+    public static FloatValue operator /(FloatValue left, FloatValue right) => new(left._valueOrThrow / right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static FloatValue operator %(FloatValue left, FloatValue right) => new(left._value % right._value);
+    public static FloatValue operator %(FloatValue left, FloatValue right) => new(left._valueOrThrow % right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <(FloatValue left, FloatValue right) => left._value < right._value;
+    public static bool operator <(FloatValue left, FloatValue right) => left._valueOrThrow < right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <=(FloatValue left, FloatValue right) => left._value <= right._value;
+    public static bool operator <=(FloatValue left, FloatValue right) => left._valueOrThrow <= right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >(FloatValue left, FloatValue right) => left._value > right._value;
+    public static bool operator >(FloatValue left, FloatValue right) => left._valueOrThrow > right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >=(FloatValue left, FloatValue right) => left._value >= right._value;
+    public static bool operator >=(FloatValue left, FloatValue right) => left._valueOrThrow >= right._valueOrThrow;
 
 
     /// <inheritdoc/>
@@ -186,67 +189,67 @@ public readonly partial struct FloatValue : IEquatable<FloatValue>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
     {
-        return ((IUtf8SpanFormattable)_value).TryFormat(utf8Destination, out bytesWritten, format, provider);
+        return ((IUtf8SpanFormattable)_valueOrThrow).TryFormat(utf8Destination, out bytesWritten, format, provider);
     }
 #endif
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override int GetHashCode() => _value.GetHashCode();
+    public override int GetHashCode() => _valueOrThrow.GetHashCode();
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(Single)_value).GetTypeCode();
+    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(Single)_valueOrThrow).GetTypeCode();
 
     /// <inheritdoc/>
-    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(Single)_value).ToBoolean(provider);
+    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(Single)_valueOrThrow).ToBoolean(provider);
 
     /// <inheritdoc/>
-    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(Single)_value).ToByte(provider);
+    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(Single)_valueOrThrow).ToByte(provider);
 
     /// <inheritdoc/>
-    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(Single)_value).ToChar(provider);
+    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(Single)_valueOrThrow).ToChar(provider);
 
     /// <inheritdoc/>
-    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(Single)_value).ToDateTime(provider);
+    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(Single)_valueOrThrow).ToDateTime(provider);
 
     /// <inheritdoc/>
-    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(Single)_value).ToDecimal(provider);
+    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(Single)_valueOrThrow).ToDecimal(provider);
 
     /// <inheritdoc/>
-    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(Single)_value).ToDouble(provider);
+    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(Single)_valueOrThrow).ToDouble(provider);
 
     /// <inheritdoc/>
-    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(Single)_value).ToInt16(provider);
+    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(Single)_valueOrThrow).ToInt16(provider);
 
     /// <inheritdoc/>
-    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(Single)_value).ToInt32(provider);
+    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(Single)_valueOrThrow).ToInt32(provider);
 
     /// <inheritdoc/>
-    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(Single)_value).ToInt64(provider);
+    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(Single)_valueOrThrow).ToInt64(provider);
 
     /// <inheritdoc/>
-    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(Single)_value).ToSByte(provider);
+    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(Single)_valueOrThrow).ToSByte(provider);
 
     /// <inheritdoc/>
-    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(Single)_value).ToSingle(provider);
+    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(Single)_valueOrThrow).ToSingle(provider);
 
     /// <inheritdoc/>
-    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(Single)_value).ToString(provider);
+    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(Single)_valueOrThrow).ToString(provider);
 
     /// <inheritdoc/>
-    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(Single)_value).ToType(conversionType, provider);
+    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(Single)_valueOrThrow).ToType(conversionType, provider);
 
     /// <inheritdoc/>
-    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(Single)_value).ToUInt16(provider);
+    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(Single)_valueOrThrow).ToUInt16(provider);
 
     /// <inheritdoc/>
-    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(Single)_value).ToUInt32(provider);
+    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(Single)_valueOrThrow).ToUInt32(provider);
 
     /// <inheritdoc/>
-    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(Single)_value).ToUInt64(provider);
+    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(Single)_valueOrThrow).ToUInt64(provider);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override string ToString() => _value.ToString();
+    public override string ToString() => _valueOrThrow.ToString();
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.FloatValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.FloatValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
@@ -36,16 +36,14 @@ public static class SwaggerTypeHelper
         {
             Type = "number",
             Format = "single",
-            Title = "FloatValue",
-            Default = new OpenApiFloat(FloatValue.Default)
+            Title = "FloatValue"
         });
         options.MapType<FloatValue?>(() => new OpenApiSchema
         {
             Type = "number",
             Format = "single",
             Nullable = true,
-            Title = "Nullable<FloatValue>",
-            Default = new OpenApiFloat(FloatValue.Default)
+            Title = "Nullable<FloatValue>"
         });
     }
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.GuidValue_GeneratesAllInterfacesAndConverters#GuidValue.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.GuidValue_GeneratesAllInterfacesAndConverters#GuidValue.g.verified.cs
@@ -38,8 +38,11 @@ public readonly partial struct GuidValue : IEquatable<GuidValue>
     /// <inheritdoc/>
      public object GetUnderlyingPrimitiveValue() => (Guid)this;
 
+    private Guid _valueOrThrow => _isInitialized ? _value : throw new InvalidDomainValueException("The domain value has not been initialized");
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly Guid _value;
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly bool _isInitialized;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="GuidValue"/> class by validating the specified <see cref="Guid"/> value using <see cref="Validate"/> static method.
@@ -49,13 +52,13 @@ public readonly partial struct GuidValue : IEquatable<GuidValue>
     {
         Validate(value);
         _value = value;
+        _isInitialized = true;
     }
 
     /// <inheritdoc/>
     [Obsolete("Domain primitive cannot be created using empty Ctor", true)]
     public GuidValue()
     {
-        _value = Default;
     }
 
     /// <inheritdoc/>
@@ -63,7 +66,7 @@ public readonly partial struct GuidValue : IEquatable<GuidValue>
     public override bool Equals(object? obj) => obj is GuidValue other && Equals(other);
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Equals(GuidValue other) => _value == other._value;
+    public bool Equals(GuidValue other) => _valueOrThrow == other._valueOrThrow;
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator ==(GuidValue left, GuidValue right) => left.Equals(right);
@@ -84,7 +87,7 @@ public readonly partial struct GuidValue : IEquatable<GuidValue>
     }
 
     /// <inheritdoc/>
-    public int CompareTo(GuidValue other) => _value.CompareTo(other._value);
+    public int CompareTo(GuidValue other) => _valueOrThrow.CompareTo(other._valueOrThrow);
 
     /// <summary>
     /// Implicit conversion from <see cref = "Guid"/> to <see cref = "GuidValue"/>
@@ -103,14 +106,14 @@ public readonly partial struct GuidValue : IEquatable<GuidValue>
     /// Implicit conversion from <see cref = "GuidValue"/> to <see cref = "Guid"/>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator Guid(GuidValue value) => (Guid)value._value;
+    public static implicit operator Guid(GuidValue value) => (Guid)value._valueOrThrow;
 
     /// <summary>
     /// Implicit conversion from <see cref = "GuidValue"/> (nullable) to <see cref = "Guid"/> (nullable)
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [return: NotNullIfNotNull(nameof(value))]
-    public static implicit operator Guid?(GuidValue? value) => value is null ? null : (Guid?)value.Value._value;
+    public static implicit operator Guid?(GuidValue? value) => value is null ? null : (Guid?)value.Value._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -140,13 +143,13 @@ public readonly partial struct GuidValue : IEquatable<GuidValue>
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public string ToString(string? format, IFormatProvider? formatProvider) => _value.ToString(format, formatProvider);
+    public string ToString(string? format, IFormatProvider? formatProvider) => _valueOrThrow.ToString(format, formatProvider);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
     {
-        return ((ISpanFormattable)_value).TryFormat(destination, out charsWritten, format, provider);
+        return ((ISpanFormattable)_valueOrThrow).TryFormat(destination, out charsWritten, format, provider);
     }
 
 
@@ -155,15 +158,15 @@ public readonly partial struct GuidValue : IEquatable<GuidValue>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
     {
-        return ((IUtf8SpanFormattable)_value).TryFormat(utf8Destination, out bytesWritten, format, provider);
+        return ((IUtf8SpanFormattable)_valueOrThrow).TryFormat(utf8Destination, out bytesWritten, format, provider);
     }
 #endif
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override int GetHashCode() => _value.GetHashCode();
+    public override int GetHashCode() => _valueOrThrow.GetHashCode();
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override string ToString() => _value.ToString();
+    public override string ToString() => _valueOrThrow.ToString();
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.GuidValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.GuidValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
@@ -36,16 +36,14 @@ public static class SwaggerTypeHelper
         {
             Type = "string",
             Format = "uuid",
-            Title = "GuidValue",
-            Default = new OpenApiString(GuidValue.Default.ToString())
+            Title = "GuidValue"
         });
         options.MapType<GuidValue?>(() => new OpenApiSchema
         {
             Type = "string",
             Format = "uuid",
             Nullable = true,
-            Title = "Nullable<GuidValue>",
-            Default = new OpenApiString(GuidValue.Default.ToString())
+            Title = "Nullable<GuidValue>"
         });
     }
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.Int16Value_GeneratesAllInterfacesAndConverters#ShortValue.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.Int16Value_GeneratesAllInterfacesAndConverters#ShortValue.g.verified.cs
@@ -39,8 +39,11 @@ public readonly partial struct ShortValue : IEquatable<ShortValue>
     /// <inheritdoc/>
      public object GetUnderlyingPrimitiveValue() => (short)this;
 
+    private short _valueOrThrow => _isInitialized ? _value : throw new InvalidDomainValueException("The domain value has not been initialized");
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly short _value;
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly bool _isInitialized;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ShortValue"/> class by validating the specified <see cref="short"/> value using <see cref="Validate"/> static method.
@@ -50,13 +53,13 @@ public readonly partial struct ShortValue : IEquatable<ShortValue>
     {
         Validate(value);
         _value = value;
+        _isInitialized = true;
     }
 
     /// <inheritdoc/>
     [Obsolete("Domain primitive cannot be created using empty Ctor", true)]
     public ShortValue()
     {
-        _value = Default;
     }
 
     /// <inheritdoc/>
@@ -64,7 +67,7 @@ public readonly partial struct ShortValue : IEquatable<ShortValue>
     public override bool Equals(object? obj) => obj is ShortValue other && Equals(other);
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Equals(ShortValue other) => _value == other._value;
+    public bool Equals(ShortValue other) => _valueOrThrow == other._valueOrThrow;
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator ==(ShortValue left, ShortValue right) => left.Equals(right);
@@ -85,7 +88,7 @@ public readonly partial struct ShortValue : IEquatable<ShortValue>
     }
 
     /// <inheritdoc/>
-    public int CompareTo(ShortValue other) => _value.CompareTo(other._value);
+    public int CompareTo(ShortValue other) => _valueOrThrow.CompareTo(other._valueOrThrow);
 
     /// <summary>
     /// Implicit conversion from <see cref = "short"/> to <see cref = "ShortValue"/>
@@ -104,30 +107,30 @@ public readonly partial struct ShortValue : IEquatable<ShortValue>
     /// Implicit conversion from <see cref = "ShortValue"/> to <see cref = "short"/>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator short(ShortValue value) => (short)value._value;
+    public static implicit operator short(ShortValue value) => (short)value._valueOrThrow;
 
     /// <summary>
     /// Implicit conversion from <see cref = "ShortValue"/> (nullable) to <see cref = "short"/> (nullable)
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [return: NotNullIfNotNull(nameof(value))]
-    public static implicit operator short?(ShortValue? value) => value is null ? null : (short?)value.Value._value;
+    public static implicit operator short?(ShortValue? value) => value is null ? null : (short?)value.Value._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <(ShortValue left, ShortValue right) => left._value < right._value;
+    public static bool operator <(ShortValue left, ShortValue right) => left._valueOrThrow < right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <=(ShortValue left, ShortValue right) => left._value <= right._value;
+    public static bool operator <=(ShortValue left, ShortValue right) => left._valueOrThrow <= right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >(ShortValue left, ShortValue right) => left._value > right._value;
+    public static bool operator >(ShortValue left, ShortValue right) => left._valueOrThrow > right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >=(ShortValue left, ShortValue right) => left._value >= right._value;
+    public static bool operator >=(ShortValue left, ShortValue right) => left._valueOrThrow >= right._valueOrThrow;
 
 
     /// <inheritdoc/>
@@ -161,67 +164,67 @@ public readonly partial struct ShortValue : IEquatable<ShortValue>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
     {
-        return ((IUtf8SpanFormattable)_value).TryFormat(utf8Destination, out bytesWritten, format, provider);
+        return ((IUtf8SpanFormattable)_valueOrThrow).TryFormat(utf8Destination, out bytesWritten, format, provider);
     }
 #endif
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override int GetHashCode() => _value.GetHashCode();
+    public override int GetHashCode() => _valueOrThrow.GetHashCode();
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(Int16)_value).GetTypeCode();
+    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(Int16)_valueOrThrow).GetTypeCode();
 
     /// <inheritdoc/>
-    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(Int16)_value).ToBoolean(provider);
+    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(Int16)_valueOrThrow).ToBoolean(provider);
 
     /// <inheritdoc/>
-    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(Int16)_value).ToByte(provider);
+    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(Int16)_valueOrThrow).ToByte(provider);
 
     /// <inheritdoc/>
-    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(Int16)_value).ToChar(provider);
+    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(Int16)_valueOrThrow).ToChar(provider);
 
     /// <inheritdoc/>
-    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(Int16)_value).ToDateTime(provider);
+    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(Int16)_valueOrThrow).ToDateTime(provider);
 
     /// <inheritdoc/>
-    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(Int16)_value).ToDecimal(provider);
+    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(Int16)_valueOrThrow).ToDecimal(provider);
 
     /// <inheritdoc/>
-    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(Int16)_value).ToDouble(provider);
+    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(Int16)_valueOrThrow).ToDouble(provider);
 
     /// <inheritdoc/>
-    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(Int16)_value).ToInt16(provider);
+    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(Int16)_valueOrThrow).ToInt16(provider);
 
     /// <inheritdoc/>
-    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(Int16)_value).ToInt32(provider);
+    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(Int16)_valueOrThrow).ToInt32(provider);
 
     /// <inheritdoc/>
-    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(Int16)_value).ToInt64(provider);
+    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(Int16)_valueOrThrow).ToInt64(provider);
 
     /// <inheritdoc/>
-    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(Int16)_value).ToSByte(provider);
+    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(Int16)_valueOrThrow).ToSByte(provider);
 
     /// <inheritdoc/>
-    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(Int16)_value).ToSingle(provider);
+    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(Int16)_valueOrThrow).ToSingle(provider);
 
     /// <inheritdoc/>
-    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(Int16)_value).ToString(provider);
+    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(Int16)_valueOrThrow).ToString(provider);
 
     /// <inheritdoc/>
-    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(Int16)_value).ToType(conversionType, provider);
+    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(Int16)_valueOrThrow).ToType(conversionType, provider);
 
     /// <inheritdoc/>
-    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(Int16)_value).ToUInt16(provider);
+    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(Int16)_valueOrThrow).ToUInt16(provider);
 
     /// <inheritdoc/>
-    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(Int16)_value).ToUInt32(provider);
+    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(Int16)_valueOrThrow).ToUInt32(provider);
 
     /// <inheritdoc/>
-    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(Int16)_value).ToUInt64(provider);
+    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(Int16)_valueOrThrow).ToUInt64(provider);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override string ToString() => _value.ToString();
+    public override string ToString() => _valueOrThrow.ToString();
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.Int16Value_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.Int16Value_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
@@ -36,16 +36,14 @@ public static class SwaggerTypeHelper
         {
             Type = "integer",
             Format = "int16",
-            Title = "ShortValue",
-            Default = new OpenApiInteger(ShortValue.Default)
+            Title = "ShortValue"
         });
         options.MapType<ShortValue?>(() => new OpenApiSchema
         {
             Type = "integer",
             Format = "int16",
             Nullable = true,
-            Title = "Nullable<ShortValue>",
-            Default = new OpenApiInteger(ShortValue.Default)
+            Title = "Nullable<ShortValue>"
         });
     }
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.IntOfIntValue_GeneratesAllInterfacesAndConverters#IntOfIntValue.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.IntOfIntValue_GeneratesAllInterfacesAndConverters#IntOfIntValue.g.verified.cs
@@ -41,8 +41,11 @@ public readonly partial struct IntOfIntValue : IEquatable<IntOfIntValue>
     /// <inheritdoc/>
      public object GetUnderlyingPrimitiveValue() => (int)this;
 
+    private IntValue _valueOrThrow => _isInitialized ? _value : throw new InvalidDomainValueException("The domain value has not been initialized");
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly IntValue _value;
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly bool _isInitialized;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="IntOfIntValue"/> class by validating the specified <see cref="IntValue"/> value using <see cref="Validate"/> static method.
@@ -52,13 +55,13 @@ public readonly partial struct IntOfIntValue : IEquatable<IntOfIntValue>
     {
         Validate(value);
         _value = value;
+        _isInitialized = true;
     }
 
     /// <inheritdoc/>
     [Obsolete("Domain primitive cannot be created using empty Ctor", true)]
     public IntOfIntValue()
     {
-        _value = Default;
     }
 
     /// <inheritdoc/>
@@ -66,7 +69,7 @@ public readonly partial struct IntOfIntValue : IEquatable<IntOfIntValue>
     public override bool Equals(object? obj) => obj is IntOfIntValue other && Equals(other);
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Equals(IntOfIntValue other) => _value == other._value;
+    public bool Equals(IntOfIntValue other) => _valueOrThrow == other._valueOrThrow;
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator ==(IntOfIntValue left, IntOfIntValue right) => left.Equals(right);
@@ -87,7 +90,7 @@ public readonly partial struct IntOfIntValue : IEquatable<IntOfIntValue>
     }
 
     /// <inheritdoc/>
-    public int CompareTo(IntOfIntValue other) => _value.CompareTo(other._value);
+    public int CompareTo(IntOfIntValue other) => _valueOrThrow.CompareTo(other._valueOrThrow);
 
     /// <summary>
     /// Implicit conversion from <see cref = "int"/> to <see cref = "IntOfIntValue"/>
@@ -106,14 +109,14 @@ public readonly partial struct IntOfIntValue : IEquatable<IntOfIntValue>
     /// Implicit conversion from <see cref = "IntOfIntValue"/> to <see cref = "int"/>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator int(IntOfIntValue value) => (int)value._value;
+    public static implicit operator int(IntOfIntValue value) => (int)value._valueOrThrow;
 
     /// <summary>
     /// Implicit conversion from <see cref = "IntOfIntValue"/> (nullable) to <see cref = "int"/> (nullable)
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [return: NotNullIfNotNull(nameof(value))]
-    public static implicit operator int?(IntOfIntValue? value) => value is null ? null : (int?)value.Value._value;
+    public static implicit operator int?(IntOfIntValue? value) => value is null ? null : (int?)value.Value._valueOrThrow;
 
     /// <summary>
     /// Implicit conversion from <see cref = "IntValue"/> to <see cref = "IntOfIntValue"/>
@@ -130,39 +133,39 @@ public readonly partial struct IntOfIntValue : IEquatable<IntOfIntValue>
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static IntOfIntValue operator +(IntOfIntValue left, IntOfIntValue right) => new(left._value + right._value);
+    public static IntOfIntValue operator +(IntOfIntValue left, IntOfIntValue right) => new(left._valueOrThrow + right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static IntOfIntValue operator -(IntOfIntValue left, IntOfIntValue right) => new(left._value - right._value);
+    public static IntOfIntValue operator -(IntOfIntValue left, IntOfIntValue right) => new(left._valueOrThrow - right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static IntOfIntValue operator *(IntOfIntValue left, IntOfIntValue right) => new(left._value * right._value);
+    public static IntOfIntValue operator *(IntOfIntValue left, IntOfIntValue right) => new(left._valueOrThrow * right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static IntOfIntValue operator /(IntOfIntValue left, IntOfIntValue right) => new(left._value / right._value);
+    public static IntOfIntValue operator /(IntOfIntValue left, IntOfIntValue right) => new(left._valueOrThrow / right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static IntOfIntValue operator %(IntOfIntValue left, IntOfIntValue right) => new(left._value % right._value);
+    public static IntOfIntValue operator %(IntOfIntValue left, IntOfIntValue right) => new(left._valueOrThrow % right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <(IntOfIntValue left, IntOfIntValue right) => left._value < right._value;
+    public static bool operator <(IntOfIntValue left, IntOfIntValue right) => left._valueOrThrow < right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <=(IntOfIntValue left, IntOfIntValue right) => left._value <= right._value;
+    public static bool operator <=(IntOfIntValue left, IntOfIntValue right) => left._valueOrThrow <= right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >(IntOfIntValue left, IntOfIntValue right) => left._value > right._value;
+    public static bool operator >(IntOfIntValue left, IntOfIntValue right) => left._valueOrThrow > right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >=(IntOfIntValue left, IntOfIntValue right) => left._value >= right._value;
+    public static bool operator >=(IntOfIntValue left, IntOfIntValue right) => left._valueOrThrow >= right._valueOrThrow;
 
 
     /// <inheritdoc/>
@@ -193,61 +196,61 @@ public readonly partial struct IntOfIntValue : IEquatable<IntOfIntValue>
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override int GetHashCode() => _value.GetHashCode();
+    public override int GetHashCode() => _valueOrThrow.GetHashCode();
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(Int32)_value).GetTypeCode();
+    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(Int32)_valueOrThrow).GetTypeCode();
 
     /// <inheritdoc/>
-    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToBoolean(provider);
+    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToBoolean(provider);
 
     /// <inheritdoc/>
-    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToByte(provider);
+    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToByte(provider);
 
     /// <inheritdoc/>
-    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToChar(provider);
+    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToChar(provider);
 
     /// <inheritdoc/>
-    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToDateTime(provider);
+    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToDateTime(provider);
 
     /// <inheritdoc/>
-    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToDecimal(provider);
+    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToDecimal(provider);
 
     /// <inheritdoc/>
-    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToDouble(provider);
+    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToDouble(provider);
 
     /// <inheritdoc/>
-    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToInt16(provider);
+    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToInt16(provider);
 
     /// <inheritdoc/>
-    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToInt32(provider);
+    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToInt32(provider);
 
     /// <inheritdoc/>
-    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToInt64(provider);
+    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToInt64(provider);
 
     /// <inheritdoc/>
-    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToSByte(provider);
+    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToSByte(provider);
 
     /// <inheritdoc/>
-    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToSingle(provider);
+    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToSingle(provider);
 
     /// <inheritdoc/>
-    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToString(provider);
+    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToString(provider);
 
     /// <inheritdoc/>
-    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToType(conversionType, provider);
+    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToType(conversionType, provider);
 
     /// <inheritdoc/>
-    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToUInt16(provider);
+    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToUInt16(provider);
 
     /// <inheritdoc/>
-    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToUInt32(provider);
+    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToUInt32(provider);
 
     /// <inheritdoc/>
-    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToUInt64(provider);
+    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToUInt64(provider);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override string ToString() => _value.ToString();
+    public override string ToString() => _valueOrThrow.ToString();
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.IntOfIntValue_GeneratesAllInterfacesAndConverters#IntValue.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.IntOfIntValue_GeneratesAllInterfacesAndConverters#IntValue.g.verified.cs
@@ -44,8 +44,11 @@ public readonly partial struct IntValue : IEquatable<IntValue>
     /// <inheritdoc/>
      public object GetUnderlyingPrimitiveValue() => (int)this;
 
+    private int _valueOrThrow => _isInitialized ? _value : throw new InvalidDomainValueException("The domain value has not been initialized");
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly int _value;
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly bool _isInitialized;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="IntValue"/> class by validating the specified <see cref="int"/> value using <see cref="Validate"/> static method.
@@ -55,13 +58,13 @@ public readonly partial struct IntValue : IEquatable<IntValue>
     {
         Validate(value);
         _value = value;
+        _isInitialized = true;
     }
 
     /// <inheritdoc/>
     [Obsolete("Domain primitive cannot be created using empty Ctor", true)]
     public IntValue()
     {
-        _value = Default;
     }
 
     /// <inheritdoc/>
@@ -69,7 +72,7 @@ public readonly partial struct IntValue : IEquatable<IntValue>
     public override bool Equals(object? obj) => obj is IntValue other && Equals(other);
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Equals(IntValue other) => _value == other._value;
+    public bool Equals(IntValue other) => _valueOrThrow == other._valueOrThrow;
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator ==(IntValue left, IntValue right) => left.Equals(right);
@@ -90,7 +93,7 @@ public readonly partial struct IntValue : IEquatable<IntValue>
     }
 
     /// <inheritdoc/>
-    public int CompareTo(IntValue other) => _value.CompareTo(other._value);
+    public int CompareTo(IntValue other) => _valueOrThrow.CompareTo(other._valueOrThrow);
 
     /// <summary>
     /// Implicit conversion from <see cref = "int"/> to <see cref = "IntValue"/>
@@ -109,50 +112,50 @@ public readonly partial struct IntValue : IEquatable<IntValue>
     /// Implicit conversion from <see cref = "IntValue"/> to <see cref = "int"/>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator int(IntValue value) => (int)value._value;
+    public static implicit operator int(IntValue value) => (int)value._valueOrThrow;
 
     /// <summary>
     /// Implicit conversion from <see cref = "IntValue"/> (nullable) to <see cref = "int"/> (nullable)
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [return: NotNullIfNotNull(nameof(value))]
-    public static implicit operator int?(IntValue? value) => value is null ? null : (int?)value.Value._value;
+    public static implicit operator int?(IntValue? value) => value is null ? null : (int?)value.Value._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static IntValue operator +(IntValue left, IntValue right) => new(left._value + right._value);
+    public static IntValue operator +(IntValue left, IntValue right) => new(left._valueOrThrow + right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static IntValue operator -(IntValue left, IntValue right) => new(left._value - right._value);
+    public static IntValue operator -(IntValue left, IntValue right) => new(left._valueOrThrow - right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static IntValue operator *(IntValue left, IntValue right) => new(left._value * right._value);
+    public static IntValue operator *(IntValue left, IntValue right) => new(left._valueOrThrow * right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static IntValue operator /(IntValue left, IntValue right) => new(left._value / right._value);
+    public static IntValue operator /(IntValue left, IntValue right) => new(left._valueOrThrow / right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static IntValue operator %(IntValue left, IntValue right) => new(left._value % right._value);
+    public static IntValue operator %(IntValue left, IntValue right) => new(left._valueOrThrow % right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <(IntValue left, IntValue right) => left._value < right._value;
+    public static bool operator <(IntValue left, IntValue right) => left._valueOrThrow < right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <=(IntValue left, IntValue right) => left._value <= right._value;
+    public static bool operator <=(IntValue left, IntValue right) => left._valueOrThrow <= right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >(IntValue left, IntValue right) => left._value > right._value;
+    public static bool operator >(IntValue left, IntValue right) => left._valueOrThrow > right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >=(IntValue left, IntValue right) => left._value >= right._value;
+    public static bool operator >=(IntValue left, IntValue right) => left._valueOrThrow >= right._valueOrThrow;
 
 
     /// <inheritdoc/>
@@ -186,67 +189,67 @@ public readonly partial struct IntValue : IEquatable<IntValue>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
     {
-        return ((IUtf8SpanFormattable)_value).TryFormat(utf8Destination, out bytesWritten, format, provider);
+        return ((IUtf8SpanFormattable)_valueOrThrow).TryFormat(utf8Destination, out bytesWritten, format, provider);
     }
 #endif
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override int GetHashCode() => _value.GetHashCode();
+    public override int GetHashCode() => _valueOrThrow.GetHashCode();
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(Int32)_value).GetTypeCode();
+    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(Int32)_valueOrThrow).GetTypeCode();
 
     /// <inheritdoc/>
-    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToBoolean(provider);
+    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToBoolean(provider);
 
     /// <inheritdoc/>
-    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToByte(provider);
+    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToByte(provider);
 
     /// <inheritdoc/>
-    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToChar(provider);
+    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToChar(provider);
 
     /// <inheritdoc/>
-    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToDateTime(provider);
+    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToDateTime(provider);
 
     /// <inheritdoc/>
-    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToDecimal(provider);
+    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToDecimal(provider);
 
     /// <inheritdoc/>
-    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToDouble(provider);
+    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToDouble(provider);
 
     /// <inheritdoc/>
-    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToInt16(provider);
+    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToInt16(provider);
 
     /// <inheritdoc/>
-    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToInt32(provider);
+    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToInt32(provider);
 
     /// <inheritdoc/>
-    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToInt64(provider);
+    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToInt64(provider);
 
     /// <inheritdoc/>
-    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToSByte(provider);
+    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToSByte(provider);
 
     /// <inheritdoc/>
-    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToSingle(provider);
+    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToSingle(provider);
 
     /// <inheritdoc/>
-    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToString(provider);
+    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToString(provider);
 
     /// <inheritdoc/>
-    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToType(conversionType, provider);
+    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToType(conversionType, provider);
 
     /// <inheritdoc/>
-    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToUInt16(provider);
+    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToUInt16(provider);
 
     /// <inheritdoc/>
-    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToUInt32(provider);
+    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToUInt32(provider);
 
     /// <inheritdoc/>
-    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToUInt64(provider);
+    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToUInt64(provider);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override string ToString() => _value.ToString();
+    public override string ToString() => _valueOrThrow.ToString();
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.IntOfIntValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.IntOfIntValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
@@ -37,31 +37,27 @@ public static class SwaggerTypeHelper
         {
             Type = "integer",
             Format = "int32",
-            Title = "IntValue",
-            Default = new OpenApiInteger(IntValue.Default)
+            Title = "IntValue"
         });
         options.MapType<IntValue?>(() => new OpenApiSchema
         {
             Type = "integer",
             Format = "int32",
             Nullable = true,
-            Title = "Nullable<IntValue>",
-            Default = new OpenApiInteger(IntValue.Default)
+            Title = "Nullable<IntValue>"
         });
         options.MapType<IntOfIntValue>(() => new OpenApiSchema
         {
             Type = "integer",
             Format = "int32",
-            Title = "IntOfIntValue",
-            Default = new OpenApiInteger(IntOfIntValue.Default)
+            Title = "IntOfIntValue"
         });
         options.MapType<IntOfIntValue?>(() => new OpenApiSchema
         {
             Type = "integer",
             Format = "int32",
             Nullable = true,
-            Title = "Nullable<IntOfIntValue>",
-            Default = new OpenApiInteger(IntOfIntValue.Default)
+            Title = "Nullable<IntOfIntValue>"
         });
     }
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.IntValue_GeneratesAllInterfacesAndConverters#IntValue.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.IntValue_GeneratesAllInterfacesAndConverters#IntValue.g.verified.cs
@@ -44,8 +44,11 @@ public readonly partial struct IntValue : IEquatable<IntValue>
     /// <inheritdoc/>
      public object GetUnderlyingPrimitiveValue() => (int)this;
 
+    private int _valueOrThrow => _isInitialized ? _value : throw new InvalidDomainValueException("The domain value has not been initialized");
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly int _value;
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly bool _isInitialized;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="IntValue"/> class by validating the specified <see cref="int"/> value using <see cref="Validate"/> static method.
@@ -55,13 +58,13 @@ public readonly partial struct IntValue : IEquatable<IntValue>
     {
         Validate(value);
         _value = value;
+        _isInitialized = true;
     }
 
     /// <inheritdoc/>
     [Obsolete("Domain primitive cannot be created using empty Ctor", true)]
     public IntValue()
     {
-        _value = Default;
     }
 
     /// <inheritdoc/>
@@ -69,7 +72,7 @@ public readonly partial struct IntValue : IEquatable<IntValue>
     public override bool Equals(object? obj) => obj is IntValue other && Equals(other);
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Equals(IntValue other) => _value == other._value;
+    public bool Equals(IntValue other) => _valueOrThrow == other._valueOrThrow;
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator ==(IntValue left, IntValue right) => left.Equals(right);
@@ -90,7 +93,7 @@ public readonly partial struct IntValue : IEquatable<IntValue>
     }
 
     /// <inheritdoc/>
-    public int CompareTo(IntValue other) => _value.CompareTo(other._value);
+    public int CompareTo(IntValue other) => _valueOrThrow.CompareTo(other._valueOrThrow);
 
     /// <summary>
     /// Implicit conversion from <see cref = "int"/> to <see cref = "IntValue"/>
@@ -109,50 +112,50 @@ public readonly partial struct IntValue : IEquatable<IntValue>
     /// Implicit conversion from <see cref = "IntValue"/> to <see cref = "int"/>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator int(IntValue value) => (int)value._value;
+    public static implicit operator int(IntValue value) => (int)value._valueOrThrow;
 
     /// <summary>
     /// Implicit conversion from <see cref = "IntValue"/> (nullable) to <see cref = "int"/> (nullable)
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [return: NotNullIfNotNull(nameof(value))]
-    public static implicit operator int?(IntValue? value) => value is null ? null : (int?)value.Value._value;
+    public static implicit operator int?(IntValue? value) => value is null ? null : (int?)value.Value._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static IntValue operator +(IntValue left, IntValue right) => new(left._value + right._value);
+    public static IntValue operator +(IntValue left, IntValue right) => new(left._valueOrThrow + right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static IntValue operator -(IntValue left, IntValue right) => new(left._value - right._value);
+    public static IntValue operator -(IntValue left, IntValue right) => new(left._valueOrThrow - right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static IntValue operator *(IntValue left, IntValue right) => new(left._value * right._value);
+    public static IntValue operator *(IntValue left, IntValue right) => new(left._valueOrThrow * right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static IntValue operator /(IntValue left, IntValue right) => new(left._value / right._value);
+    public static IntValue operator /(IntValue left, IntValue right) => new(left._valueOrThrow / right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static IntValue operator %(IntValue left, IntValue right) => new(left._value % right._value);
+    public static IntValue operator %(IntValue left, IntValue right) => new(left._valueOrThrow % right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <(IntValue left, IntValue right) => left._value < right._value;
+    public static bool operator <(IntValue left, IntValue right) => left._valueOrThrow < right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <=(IntValue left, IntValue right) => left._value <= right._value;
+    public static bool operator <=(IntValue left, IntValue right) => left._valueOrThrow <= right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >(IntValue left, IntValue right) => left._value > right._value;
+    public static bool operator >(IntValue left, IntValue right) => left._valueOrThrow > right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >=(IntValue left, IntValue right) => left._value >= right._value;
+    public static bool operator >=(IntValue left, IntValue right) => left._valueOrThrow >= right._valueOrThrow;
 
 
     /// <inheritdoc/>
@@ -186,67 +189,67 @@ public readonly partial struct IntValue : IEquatable<IntValue>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
     {
-        return ((IUtf8SpanFormattable)_value).TryFormat(utf8Destination, out bytesWritten, format, provider);
+        return ((IUtf8SpanFormattable)_valueOrThrow).TryFormat(utf8Destination, out bytesWritten, format, provider);
     }
 #endif
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override int GetHashCode() => _value.GetHashCode();
+    public override int GetHashCode() => _valueOrThrow.GetHashCode();
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(Int32)_value).GetTypeCode();
+    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(Int32)_valueOrThrow).GetTypeCode();
 
     /// <inheritdoc/>
-    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToBoolean(provider);
+    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToBoolean(provider);
 
     /// <inheritdoc/>
-    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToByte(provider);
+    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToByte(provider);
 
     /// <inheritdoc/>
-    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToChar(provider);
+    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToChar(provider);
 
     /// <inheritdoc/>
-    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToDateTime(provider);
+    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToDateTime(provider);
 
     /// <inheritdoc/>
-    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToDecimal(provider);
+    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToDecimal(provider);
 
     /// <inheritdoc/>
-    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToDouble(provider);
+    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToDouble(provider);
 
     /// <inheritdoc/>
-    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToInt16(provider);
+    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToInt16(provider);
 
     /// <inheritdoc/>
-    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToInt32(provider);
+    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToInt32(provider);
 
     /// <inheritdoc/>
-    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToInt64(provider);
+    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToInt64(provider);
 
     /// <inheritdoc/>
-    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToSByte(provider);
+    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToSByte(provider);
 
     /// <inheritdoc/>
-    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToSingle(provider);
+    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToSingle(provider);
 
     /// <inheritdoc/>
-    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToString(provider);
+    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToString(provider);
 
     /// <inheritdoc/>
-    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToType(conversionType, provider);
+    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToType(conversionType, provider);
 
     /// <inheritdoc/>
-    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToUInt16(provider);
+    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToUInt16(provider);
 
     /// <inheritdoc/>
-    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToUInt32(provider);
+    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToUInt32(provider);
 
     /// <inheritdoc/>
-    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(Int32)_value).ToUInt64(provider);
+    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(Int32)_valueOrThrow).ToUInt64(provider);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override string ToString() => _value.ToString();
+    public override string ToString() => _valueOrThrow.ToString();
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.IntValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.IntValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
@@ -36,16 +36,14 @@ public static class SwaggerTypeHelper
         {
             Type = "integer",
             Format = "int32",
-            Title = "IntValue",
-            Default = new OpenApiInteger(IntValue.Default)
+            Title = "IntValue"
         });
         options.MapType<IntValue?>(() => new OpenApiSchema
         {
             Type = "integer",
             Format = "int32",
             Nullable = true,
-            Title = "Nullable<IntValue>",
-            Default = new OpenApiInteger(IntValue.Default)
+            Title = "Nullable<IntValue>"
         });
     }
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.LongValue_GeneratesAllInterfacesAndConverters#LongValue.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.LongValue_GeneratesAllInterfacesAndConverters#LongValue.g.verified.cs
@@ -44,8 +44,11 @@ public readonly partial struct LongValue : IEquatable<LongValue>
     /// <inheritdoc/>
      public object GetUnderlyingPrimitiveValue() => (long)this;
 
+    private long _valueOrThrow => _isInitialized ? _value : throw new InvalidDomainValueException("The domain value has not been initialized");
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly long _value;
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly bool _isInitialized;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="LongValue"/> class by validating the specified <see cref="long"/> value using <see cref="Validate"/> static method.
@@ -55,13 +58,13 @@ public readonly partial struct LongValue : IEquatable<LongValue>
     {
         Validate(value);
         _value = value;
+        _isInitialized = true;
     }
 
     /// <inheritdoc/>
     [Obsolete("Domain primitive cannot be created using empty Ctor", true)]
     public LongValue()
     {
-        _value = Default;
     }
 
     /// <inheritdoc/>
@@ -69,7 +72,7 @@ public readonly partial struct LongValue : IEquatable<LongValue>
     public override bool Equals(object? obj) => obj is LongValue other && Equals(other);
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Equals(LongValue other) => _value == other._value;
+    public bool Equals(LongValue other) => _valueOrThrow == other._valueOrThrow;
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator ==(LongValue left, LongValue right) => left.Equals(right);
@@ -90,7 +93,7 @@ public readonly partial struct LongValue : IEquatable<LongValue>
     }
 
     /// <inheritdoc/>
-    public int CompareTo(LongValue other) => _value.CompareTo(other._value);
+    public int CompareTo(LongValue other) => _valueOrThrow.CompareTo(other._valueOrThrow);
 
     /// <summary>
     /// Implicit conversion from <see cref = "long"/> to <see cref = "LongValue"/>
@@ -109,50 +112,50 @@ public readonly partial struct LongValue : IEquatable<LongValue>
     /// Implicit conversion from <see cref = "LongValue"/> to <see cref = "long"/>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator long(LongValue value) => (long)value._value;
+    public static implicit operator long(LongValue value) => (long)value._valueOrThrow;
 
     /// <summary>
     /// Implicit conversion from <see cref = "LongValue"/> (nullable) to <see cref = "long"/> (nullable)
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [return: NotNullIfNotNull(nameof(value))]
-    public static implicit operator long?(LongValue? value) => value is null ? null : (long?)value.Value._value;
+    public static implicit operator long?(LongValue? value) => value is null ? null : (long?)value.Value._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static LongValue operator +(LongValue left, LongValue right) => new(left._value + right._value);
+    public static LongValue operator +(LongValue left, LongValue right) => new(left._valueOrThrow + right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static LongValue operator -(LongValue left, LongValue right) => new(left._value - right._value);
+    public static LongValue operator -(LongValue left, LongValue right) => new(left._valueOrThrow - right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static LongValue operator *(LongValue left, LongValue right) => new(left._value * right._value);
+    public static LongValue operator *(LongValue left, LongValue right) => new(left._valueOrThrow * right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static LongValue operator /(LongValue left, LongValue right) => new(left._value / right._value);
+    public static LongValue operator /(LongValue left, LongValue right) => new(left._valueOrThrow / right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static LongValue operator %(LongValue left, LongValue right) => new(left._value % right._value);
+    public static LongValue operator %(LongValue left, LongValue right) => new(left._valueOrThrow % right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <(LongValue left, LongValue right) => left._value < right._value;
+    public static bool operator <(LongValue left, LongValue right) => left._valueOrThrow < right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <=(LongValue left, LongValue right) => left._value <= right._value;
+    public static bool operator <=(LongValue left, LongValue right) => left._valueOrThrow <= right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >(LongValue left, LongValue right) => left._value > right._value;
+    public static bool operator >(LongValue left, LongValue right) => left._valueOrThrow > right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >=(LongValue left, LongValue right) => left._value >= right._value;
+    public static bool operator >=(LongValue left, LongValue right) => left._valueOrThrow >= right._valueOrThrow;
 
 
     /// <inheritdoc/>
@@ -186,67 +189,67 @@ public readonly partial struct LongValue : IEquatable<LongValue>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
     {
-        return ((IUtf8SpanFormattable)_value).TryFormat(utf8Destination, out bytesWritten, format, provider);
+        return ((IUtf8SpanFormattable)_valueOrThrow).TryFormat(utf8Destination, out bytesWritten, format, provider);
     }
 #endif
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override int GetHashCode() => _value.GetHashCode();
+    public override int GetHashCode() => _valueOrThrow.GetHashCode();
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(Int64)_value).GetTypeCode();
+    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(Int64)_valueOrThrow).GetTypeCode();
 
     /// <inheritdoc/>
-    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(Int64)_value).ToBoolean(provider);
+    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(Int64)_valueOrThrow).ToBoolean(provider);
 
     /// <inheritdoc/>
-    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(Int64)_value).ToByte(provider);
+    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(Int64)_valueOrThrow).ToByte(provider);
 
     /// <inheritdoc/>
-    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(Int64)_value).ToChar(provider);
+    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(Int64)_valueOrThrow).ToChar(provider);
 
     /// <inheritdoc/>
-    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(Int64)_value).ToDateTime(provider);
+    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(Int64)_valueOrThrow).ToDateTime(provider);
 
     /// <inheritdoc/>
-    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(Int64)_value).ToDecimal(provider);
+    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(Int64)_valueOrThrow).ToDecimal(provider);
 
     /// <inheritdoc/>
-    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(Int64)_value).ToDouble(provider);
+    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(Int64)_valueOrThrow).ToDouble(provider);
 
     /// <inheritdoc/>
-    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(Int64)_value).ToInt16(provider);
+    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(Int64)_valueOrThrow).ToInt16(provider);
 
     /// <inheritdoc/>
-    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(Int64)_value).ToInt32(provider);
+    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(Int64)_valueOrThrow).ToInt32(provider);
 
     /// <inheritdoc/>
-    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(Int64)_value).ToInt64(provider);
+    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(Int64)_valueOrThrow).ToInt64(provider);
 
     /// <inheritdoc/>
-    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(Int64)_value).ToSByte(provider);
+    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(Int64)_valueOrThrow).ToSByte(provider);
 
     /// <inheritdoc/>
-    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(Int64)_value).ToSingle(provider);
+    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(Int64)_valueOrThrow).ToSingle(provider);
 
     /// <inheritdoc/>
-    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(Int64)_value).ToString(provider);
+    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(Int64)_valueOrThrow).ToString(provider);
 
     /// <inheritdoc/>
-    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(Int64)_value).ToType(conversionType, provider);
+    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(Int64)_valueOrThrow).ToType(conversionType, provider);
 
     /// <inheritdoc/>
-    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(Int64)_value).ToUInt16(provider);
+    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(Int64)_valueOrThrow).ToUInt16(provider);
 
     /// <inheritdoc/>
-    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(Int64)_value).ToUInt32(provider);
+    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(Int64)_valueOrThrow).ToUInt32(provider);
 
     /// <inheritdoc/>
-    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(Int64)_value).ToUInt64(provider);
+    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(Int64)_valueOrThrow).ToUInt64(provider);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override string ToString() => _value.ToString();
+    public override string ToString() => _valueOrThrow.ToString();
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.LongValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.LongValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
@@ -36,16 +36,14 @@ public static class SwaggerTypeHelper
         {
             Type = "integer",
             Format = "int64",
-            Title = "LongValue",
-            Default = new OpenApiLong(LongValue.Default)
+            Title = "LongValue"
         });
         options.MapType<LongValue?>(() => new OpenApiSchema
         {
             Type = "integer",
             Format = "int64",
             Nullable = true,
-            Title = "Nullable<LongValue>",
-            Default = new OpenApiLong(LongValue.Default)
+            Title = "Nullable<LongValue>"
         });
     }
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.SByteValue_GeneratesAllInterfacesAndConverters#SByteValue.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.SByteValue_GeneratesAllInterfacesAndConverters#SByteValue.g.verified.cs
@@ -39,8 +39,11 @@ public readonly partial struct SByteValue : IEquatable<SByteValue>
     /// <inheritdoc/>
      public object GetUnderlyingPrimitiveValue() => (sbyte)this;
 
+    private sbyte _valueOrThrow => _isInitialized ? _value : throw new InvalidDomainValueException("The domain value has not been initialized");
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly sbyte _value;
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly bool _isInitialized;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SByteValue"/> class by validating the specified <see cref="sbyte"/> value using <see cref="Validate"/> static method.
@@ -50,13 +53,13 @@ public readonly partial struct SByteValue : IEquatable<SByteValue>
     {
         Validate(value);
         _value = value;
+        _isInitialized = true;
     }
 
     /// <inheritdoc/>
     [Obsolete("Domain primitive cannot be created using empty Ctor", true)]
     public SByteValue()
     {
-        _value = Default;
     }
 
     /// <inheritdoc/>
@@ -64,7 +67,7 @@ public readonly partial struct SByteValue : IEquatable<SByteValue>
     public override bool Equals(object? obj) => obj is SByteValue other && Equals(other);
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Equals(SByteValue other) => _value == other._value;
+    public bool Equals(SByteValue other) => _valueOrThrow == other._valueOrThrow;
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator ==(SByteValue left, SByteValue right) => left.Equals(right);
@@ -85,7 +88,7 @@ public readonly partial struct SByteValue : IEquatable<SByteValue>
     }
 
     /// <inheritdoc/>
-    public int CompareTo(SByteValue other) => _value.CompareTo(other._value);
+    public int CompareTo(SByteValue other) => _valueOrThrow.CompareTo(other._valueOrThrow);
 
     /// <summary>
     /// Implicit conversion from <see cref = "sbyte"/> to <see cref = "SByteValue"/>
@@ -104,30 +107,30 @@ public readonly partial struct SByteValue : IEquatable<SByteValue>
     /// Implicit conversion from <see cref = "SByteValue"/> to <see cref = "sbyte"/>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator sbyte(SByteValue value) => (sbyte)value._value;
+    public static implicit operator sbyte(SByteValue value) => (sbyte)value._valueOrThrow;
 
     /// <summary>
     /// Implicit conversion from <see cref = "SByteValue"/> (nullable) to <see cref = "sbyte"/> (nullable)
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [return: NotNullIfNotNull(nameof(value))]
-    public static implicit operator sbyte?(SByteValue? value) => value is null ? null : (sbyte?)value.Value._value;
+    public static implicit operator sbyte?(SByteValue? value) => value is null ? null : (sbyte?)value.Value._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <(SByteValue left, SByteValue right) => left._value < right._value;
+    public static bool operator <(SByteValue left, SByteValue right) => left._valueOrThrow < right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <=(SByteValue left, SByteValue right) => left._value <= right._value;
+    public static bool operator <=(SByteValue left, SByteValue right) => left._valueOrThrow <= right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >(SByteValue left, SByteValue right) => left._value > right._value;
+    public static bool operator >(SByteValue left, SByteValue right) => left._valueOrThrow > right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >=(SByteValue left, SByteValue right) => left._value >= right._value;
+    public static bool operator >=(SByteValue left, SByteValue right) => left._valueOrThrow >= right._valueOrThrow;
 
 
     /// <inheritdoc/>
@@ -161,67 +164,67 @@ public readonly partial struct SByteValue : IEquatable<SByteValue>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
     {
-        return ((IUtf8SpanFormattable)_value).TryFormat(utf8Destination, out bytesWritten, format, provider);
+        return ((IUtf8SpanFormattable)_valueOrThrow).TryFormat(utf8Destination, out bytesWritten, format, provider);
     }
 #endif
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override int GetHashCode() => _value.GetHashCode();
+    public override int GetHashCode() => _valueOrThrow.GetHashCode();
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(SByte)_value).GetTypeCode();
+    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(SByte)_valueOrThrow).GetTypeCode();
 
     /// <inheritdoc/>
-    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(SByte)_value).ToBoolean(provider);
+    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(SByte)_valueOrThrow).ToBoolean(provider);
 
     /// <inheritdoc/>
-    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(SByte)_value).ToByte(provider);
+    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(SByte)_valueOrThrow).ToByte(provider);
 
     /// <inheritdoc/>
-    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(SByte)_value).ToChar(provider);
+    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(SByte)_valueOrThrow).ToChar(provider);
 
     /// <inheritdoc/>
-    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(SByte)_value).ToDateTime(provider);
+    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(SByte)_valueOrThrow).ToDateTime(provider);
 
     /// <inheritdoc/>
-    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(SByte)_value).ToDecimal(provider);
+    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(SByte)_valueOrThrow).ToDecimal(provider);
 
     /// <inheritdoc/>
-    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(SByte)_value).ToDouble(provider);
+    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(SByte)_valueOrThrow).ToDouble(provider);
 
     /// <inheritdoc/>
-    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(SByte)_value).ToInt16(provider);
+    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(SByte)_valueOrThrow).ToInt16(provider);
 
     /// <inheritdoc/>
-    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(SByte)_value).ToInt32(provider);
+    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(SByte)_valueOrThrow).ToInt32(provider);
 
     /// <inheritdoc/>
-    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(SByte)_value).ToInt64(provider);
+    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(SByte)_valueOrThrow).ToInt64(provider);
 
     /// <inheritdoc/>
-    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(SByte)_value).ToSByte(provider);
+    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(SByte)_valueOrThrow).ToSByte(provider);
 
     /// <inheritdoc/>
-    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(SByte)_value).ToSingle(provider);
+    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(SByte)_valueOrThrow).ToSingle(provider);
 
     /// <inheritdoc/>
-    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(SByte)_value).ToString(provider);
+    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(SByte)_valueOrThrow).ToString(provider);
 
     /// <inheritdoc/>
-    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(SByte)_value).ToType(conversionType, provider);
+    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(SByte)_valueOrThrow).ToType(conversionType, provider);
 
     /// <inheritdoc/>
-    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(SByte)_value).ToUInt16(provider);
+    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(SByte)_valueOrThrow).ToUInt16(provider);
 
     /// <inheritdoc/>
-    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(SByte)_value).ToUInt32(provider);
+    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(SByte)_valueOrThrow).ToUInt32(provider);
 
     /// <inheritdoc/>
-    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(SByte)_value).ToUInt64(provider);
+    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(SByte)_valueOrThrow).ToUInt64(provider);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override string ToString() => _value.ToString();
+    public override string ToString() => _valueOrThrow.ToString();
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.SByteValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.SByteValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
@@ -36,16 +36,14 @@ public static class SwaggerTypeHelper
         {
             Type = "integer",
             Format = "sbyte",
-            Title = "SByteValue",
-            Default = new OpenApiByte((byte)SByteValue.Default)
+            Title = "SByteValue"
         });
         options.MapType<SByteValue?>(() => new OpenApiSchema
         {
             Type = "integer",
             Format = "sbyte",
             Nullable = true,
-            Title = "Nullable<SByteValue>",
-            Default = new OpenApiByte((byte)SByteValue.Default)
+            Title = "Nullable<SByteValue>"
         });
     }
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.StringOfStringValue_GeneratesAllInterfacesAndConverters#StringOfStringValue.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.StringOfStringValue_GeneratesAllInterfacesAndConverters#StringOfStringValue.g.verified.cs
@@ -35,8 +35,11 @@ public partial class StringOfStringValue : IEquatable<StringOfStringValue>
     /// <inheritdoc/>
      public object GetUnderlyingPrimitiveValue() => (string)this;
 
+    private StringValue _valueOrThrow => _isInitialized ? _value : throw new InvalidDomainValueException("The domain value has not been initialized");
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly StringValue _value;
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly bool _isInitialized;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="StringOfStringValue"/> class by validating the specified <see cref="StringValue"/> value using <see cref="Validate"/> static method.
@@ -46,6 +49,7 @@ public partial class StringOfStringValue : IEquatable<StringOfStringValue>
     {
         Validate(value);
         _value = value;
+        _isInitialized = true;
     }
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
@@ -53,7 +57,6 @@ public partial class StringOfStringValue : IEquatable<StringOfStringValue>
     [Obsolete("Domain primitive cannot be created using empty Ctor", true)]
     public StringOfStringValue()
     {
-        _value = Default;
     }
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
@@ -62,7 +65,7 @@ public partial class StringOfStringValue : IEquatable<StringOfStringValue>
     public override bool Equals(object? obj) => obj is StringOfStringValue other && Equals(other);
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Equals(StringOfStringValue? other) => _value == other?._value;
+    public bool Equals(StringOfStringValue? other) => _valueOrThrow == other?._valueOrThrow;
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator ==(StringOfStringValue? left, StringOfStringValue? right)
@@ -90,7 +93,7 @@ public partial class StringOfStringValue : IEquatable<StringOfStringValue>
     }
 
     /// <inheritdoc/>
-    public int CompareTo(StringOfStringValue? other) => _value.CompareTo(other?._value);
+    public int CompareTo(StringOfStringValue? other) => _valueOrThrow.CompareTo(other?._valueOrThrow);
 
     /// <summary>
     /// Implicit conversion from <see cref = "string"/> (nullable) to <see cref = "StringOfStringValue"/> (nullable)
@@ -104,7 +107,7 @@ public partial class StringOfStringValue : IEquatable<StringOfStringValue>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [return: NotNullIfNotNull(nameof(value))]
-    public static implicit operator string?(StringOfStringValue? value) => value is null ? null : (string?)value._value;
+    public static implicit operator string?(StringOfStringValue? value) => value is null ? null : (string?)value._valueOrThrow;
 
     /// <summary>
     /// Implicit conversion from <see cref = "StringValue"/> (nullable) to <see cref = "StringOfStringValue"/> (nullable)
@@ -141,61 +144,61 @@ public partial class StringOfStringValue : IEquatable<StringOfStringValue>
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override int GetHashCode() => _value.GetHashCode();
+    public override int GetHashCode() => _valueOrThrow.GetHashCode();
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(String)_value).GetTypeCode();
+    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(String)_valueOrThrow).GetTypeCode();
 
     /// <inheritdoc/>
-    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(String)_value).ToBoolean(provider);
+    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToBoolean(provider);
 
     /// <inheritdoc/>
-    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(String)_value).ToByte(provider);
+    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToByte(provider);
 
     /// <inheritdoc/>
-    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(String)_value).ToChar(provider);
+    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToChar(provider);
 
     /// <inheritdoc/>
-    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(String)_value).ToDateTime(provider);
+    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToDateTime(provider);
 
     /// <inheritdoc/>
-    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(String)_value).ToDecimal(provider);
+    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToDecimal(provider);
 
     /// <inheritdoc/>
-    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(String)_value).ToDouble(provider);
+    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToDouble(provider);
 
     /// <inheritdoc/>
-    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(String)_value).ToInt16(provider);
+    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToInt16(provider);
 
     /// <inheritdoc/>
-    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(String)_value).ToInt32(provider);
+    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToInt32(provider);
 
     /// <inheritdoc/>
-    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(String)_value).ToInt64(provider);
+    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToInt64(provider);
 
     /// <inheritdoc/>
-    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(String)_value).ToSByte(provider);
+    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToSByte(provider);
 
     /// <inheritdoc/>
-    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(String)_value).ToSingle(provider);
+    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToSingle(provider);
 
     /// <inheritdoc/>
-    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(String)_value).ToString(provider);
+    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToString(provider);
 
     /// <inheritdoc/>
-    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(String)_value).ToType(conversionType, provider);
+    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToType(conversionType, provider);
 
     /// <inheritdoc/>
-    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(String)_value).ToUInt16(provider);
+    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToUInt16(provider);
 
     /// <inheritdoc/>
-    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(String)_value).ToUInt32(provider);
+    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToUInt32(provider);
 
     /// <inheritdoc/>
-    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(String)_value).ToUInt64(provider);
+    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToUInt64(provider);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override string ToString() => _value.ToString();
+    public override string ToString() => _valueOrThrow.ToString();
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.StringOfStringValue_GeneratesAllInterfacesAndConverters#StringValue.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.StringOfStringValue_GeneratesAllInterfacesAndConverters#StringValue.g.verified.cs
@@ -35,8 +35,11 @@ public partial class StringValue : IEquatable<StringValue>
     /// <inheritdoc/>
      public object GetUnderlyingPrimitiveValue() => (string)this;
 
+    private string _valueOrThrow => _isInitialized ? _value : throw new InvalidDomainValueException("The domain value has not been initialized");
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly string _value;
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly bool _isInitialized;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="StringValue"/> class by validating the specified <see cref="string"/> value using <see cref="Validate"/> static method.
@@ -46,6 +49,7 @@ public partial class StringValue : IEquatable<StringValue>
     {
         Validate(value);
         _value = value;
+        _isInitialized = true;
     }
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
@@ -53,7 +57,6 @@ public partial class StringValue : IEquatable<StringValue>
     [Obsolete("Domain primitive cannot be created using empty Ctor", true)]
     public StringValue()
     {
-        _value = Default;
     }
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
@@ -62,7 +65,7 @@ public partial class StringValue : IEquatable<StringValue>
     public override bool Equals(object? obj) => obj is StringValue other && Equals(other);
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Equals(StringValue? other) => _value == other?._value;
+    public bool Equals(StringValue? other) => _valueOrThrow == other?._valueOrThrow;
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator ==(StringValue? left, StringValue? right)
@@ -90,7 +93,7 @@ public partial class StringValue : IEquatable<StringValue>
     }
 
     /// <inheritdoc/>
-    public int CompareTo(StringValue? other) => _value.CompareTo(other?._value);
+    public int CompareTo(StringValue? other) => _valueOrThrow.CompareTo(other?._valueOrThrow);
 
     /// <summary>
     /// Implicit conversion from <see cref = "string"/> (nullable) to <see cref = "StringValue"/> (nullable)
@@ -104,7 +107,7 @@ public partial class StringValue : IEquatable<StringValue>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [return: NotNullIfNotNull(nameof(value))]
-    public static implicit operator string?(StringValue? value) => value is null ? null : (string?)value._value;
+    public static implicit operator string?(StringValue? value) => value is null ? null : (string?)value._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -134,61 +137,61 @@ public partial class StringValue : IEquatable<StringValue>
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override int GetHashCode() => _value.GetHashCode();
+    public override int GetHashCode() => _valueOrThrow.GetHashCode();
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(String)_value).GetTypeCode();
+    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(String)_valueOrThrow).GetTypeCode();
 
     /// <inheritdoc/>
-    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(String)_value).ToBoolean(provider);
+    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToBoolean(provider);
 
     /// <inheritdoc/>
-    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(String)_value).ToByte(provider);
+    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToByte(provider);
 
     /// <inheritdoc/>
-    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(String)_value).ToChar(provider);
+    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToChar(provider);
 
     /// <inheritdoc/>
-    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(String)_value).ToDateTime(provider);
+    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToDateTime(provider);
 
     /// <inheritdoc/>
-    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(String)_value).ToDecimal(provider);
+    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToDecimal(provider);
 
     /// <inheritdoc/>
-    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(String)_value).ToDouble(provider);
+    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToDouble(provider);
 
     /// <inheritdoc/>
-    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(String)_value).ToInt16(provider);
+    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToInt16(provider);
 
     /// <inheritdoc/>
-    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(String)_value).ToInt32(provider);
+    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToInt32(provider);
 
     /// <inheritdoc/>
-    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(String)_value).ToInt64(provider);
+    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToInt64(provider);
 
     /// <inheritdoc/>
-    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(String)_value).ToSByte(provider);
+    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToSByte(provider);
 
     /// <inheritdoc/>
-    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(String)_value).ToSingle(provider);
+    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToSingle(provider);
 
     /// <inheritdoc/>
-    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(String)_value).ToString(provider);
+    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToString(provider);
 
     /// <inheritdoc/>
-    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(String)_value).ToType(conversionType, provider);
+    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToType(conversionType, provider);
 
     /// <inheritdoc/>
-    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(String)_value).ToUInt16(provider);
+    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToUInt16(provider);
 
     /// <inheritdoc/>
-    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(String)_value).ToUInt32(provider);
+    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToUInt32(provider);
 
     /// <inheritdoc/>
-    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(String)_value).ToUInt64(provider);
+    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToUInt64(provider);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override string ToString() => _value.ToString();
+    public override string ToString() => _valueOrThrow.ToString();
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.StringOfStringValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.StringOfStringValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
@@ -36,14 +36,12 @@ public static class SwaggerTypeHelper
         options.MapType<StringValue>(() => new OpenApiSchema
         {
             Type = "string",
-            Title = "StringValue",
-            Default = new OpenApiString(StringValue.Default)
+            Title = "StringValue"
         });
         options.MapType<StringOfStringValue>(() => new OpenApiSchema
         {
             Type = "string",
-            Title = "StringOfStringValue",
-            Default = new OpenApiString(StringOfStringValue.Default)
+            Title = "StringOfStringValue"
         });
     }
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.StringValue_GeneratesAllInterfacesAndConverters#StringValue.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.StringValue_GeneratesAllInterfacesAndConverters#StringValue.g.verified.cs
@@ -35,8 +35,11 @@ public partial class StringValue : IEquatable<StringValue>
     /// <inheritdoc/>
      public object GetUnderlyingPrimitiveValue() => (string)this;
 
+    private string _valueOrThrow => _isInitialized ? _value : throw new InvalidDomainValueException("The domain value has not been initialized");
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly string _value;
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly bool _isInitialized;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="StringValue"/> class by validating the specified <see cref="string"/> value using <see cref="Validate"/> static method.
@@ -46,6 +49,7 @@ public partial class StringValue : IEquatable<StringValue>
     {
         Validate(value);
         _value = value;
+        _isInitialized = true;
     }
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
@@ -53,7 +57,6 @@ public partial class StringValue : IEquatable<StringValue>
     [Obsolete("Domain primitive cannot be created using empty Ctor", true)]
     public StringValue()
     {
-        _value = Default;
     }
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
@@ -62,7 +65,7 @@ public partial class StringValue : IEquatable<StringValue>
     public override bool Equals(object? obj) => obj is StringValue other && Equals(other);
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Equals(StringValue? other) => _value == other?._value;
+    public bool Equals(StringValue? other) => _valueOrThrow == other?._valueOrThrow;
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator ==(StringValue? left, StringValue? right)
@@ -90,7 +93,7 @@ public partial class StringValue : IEquatable<StringValue>
     }
 
     /// <inheritdoc/>
-    public int CompareTo(StringValue? other) => _value.CompareTo(other?._value);
+    public int CompareTo(StringValue? other) => _valueOrThrow.CompareTo(other?._valueOrThrow);
 
     /// <summary>
     /// Implicit conversion from <see cref = "string"/> (nullable) to <see cref = "StringValue"/> (nullable)
@@ -104,7 +107,7 @@ public partial class StringValue : IEquatable<StringValue>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [return: NotNullIfNotNull(nameof(value))]
-    public static implicit operator string?(StringValue? value) => value is null ? null : (string?)value._value;
+    public static implicit operator string?(StringValue? value) => value is null ? null : (string?)value._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -134,61 +137,61 @@ public partial class StringValue : IEquatable<StringValue>
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override int GetHashCode() => _value.GetHashCode();
+    public override int GetHashCode() => _valueOrThrow.GetHashCode();
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(String)_value).GetTypeCode();
+    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(String)_valueOrThrow).GetTypeCode();
 
     /// <inheritdoc/>
-    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(String)_value).ToBoolean(provider);
+    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToBoolean(provider);
 
     /// <inheritdoc/>
-    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(String)_value).ToByte(provider);
+    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToByte(provider);
 
     /// <inheritdoc/>
-    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(String)_value).ToChar(provider);
+    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToChar(provider);
 
     /// <inheritdoc/>
-    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(String)_value).ToDateTime(provider);
+    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToDateTime(provider);
 
     /// <inheritdoc/>
-    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(String)_value).ToDecimal(provider);
+    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToDecimal(provider);
 
     /// <inheritdoc/>
-    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(String)_value).ToDouble(provider);
+    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToDouble(provider);
 
     /// <inheritdoc/>
-    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(String)_value).ToInt16(provider);
+    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToInt16(provider);
 
     /// <inheritdoc/>
-    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(String)_value).ToInt32(provider);
+    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToInt32(provider);
 
     /// <inheritdoc/>
-    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(String)_value).ToInt64(provider);
+    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToInt64(provider);
 
     /// <inheritdoc/>
-    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(String)_value).ToSByte(provider);
+    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToSByte(provider);
 
     /// <inheritdoc/>
-    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(String)_value).ToSingle(provider);
+    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToSingle(provider);
 
     /// <inheritdoc/>
-    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(String)_value).ToString(provider);
+    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToString(provider);
 
     /// <inheritdoc/>
-    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(String)_value).ToType(conversionType, provider);
+    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToType(conversionType, provider);
 
     /// <inheritdoc/>
-    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(String)_value).ToUInt16(provider);
+    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToUInt16(provider);
 
     /// <inheritdoc/>
-    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(String)_value).ToUInt32(provider);
+    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToUInt32(provider);
 
     /// <inheritdoc/>
-    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(String)_value).ToUInt64(provider);
+    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(String)_valueOrThrow).ToUInt64(provider);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override string ToString() => _value.ToString();
+    public override string ToString() => _valueOrThrow.ToString();
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.StringValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.StringValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
@@ -35,8 +35,7 @@ public static class SwaggerTypeHelper
         options.MapType<StringValue>(() => new OpenApiSchema
         {
             Type = "string",
-            Title = "StringValue",
-            Default = new OpenApiString(StringValue.Default)
+            Title = "StringValue"
         });
     }
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.TimeOnlyValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.TimeOnlyValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
@@ -36,16 +36,14 @@ public static class SwaggerTypeHelper
         {
             Type = "string",
             Format = "HH:mm:ss",
-            Title = "TimeOnlyValue",
-            Default = new OpenApiString(TimeOnlyValue.Default.ToString("hh:mm:ss", null))
+            Title = "TimeOnlyValue"
         });
         options.MapType<TimeOnlyValue?>(() => new OpenApiSchema
         {
             Type = "string",
             Format = "HH:mm:ss",
             Nullable = true,
-            Title = "Nullable<TimeOnlyValue>",
-            Default = new OpenApiString(TimeOnlyValue.Default.ToString("hh:mm:ss", null))
+            Title = "Nullable<TimeOnlyValue>"
         });
     }
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.TimeOnlyValue_GeneratesAllInterfacesAndConverters#TimeOnlyValue.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.TimeOnlyValue_GeneratesAllInterfacesAndConverters#TimeOnlyValue.g.verified.cs
@@ -40,8 +40,11 @@ public readonly partial struct TimeOnlyValue : IEquatable<TimeOnlyValue>
     /// <inheritdoc/>
      public object GetUnderlyingPrimitiveValue() => (TimeOnly)this;
 
+    private TimeOnly _valueOrThrow => _isInitialized ? _value : throw new InvalidDomainValueException("The domain value has not been initialized");
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly TimeOnly _value;
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly bool _isInitialized;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TimeOnlyValue"/> class by validating the specified <see cref="TimeOnly"/> value using <see cref="Validate"/> static method.
@@ -51,13 +54,13 @@ public readonly partial struct TimeOnlyValue : IEquatable<TimeOnlyValue>
     {
         Validate(value);
         _value = value;
+        _isInitialized = true;
     }
 
     /// <inheritdoc/>
     [Obsolete("Domain primitive cannot be created using empty Ctor", true)]
     public TimeOnlyValue()
     {
-        _value = Default;
     }
 
     /// <inheritdoc/>
@@ -65,7 +68,7 @@ public readonly partial struct TimeOnlyValue : IEquatable<TimeOnlyValue>
     public override bool Equals(object? obj) => obj is TimeOnlyValue other && Equals(other);
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Equals(TimeOnlyValue other) => _value == other._value;
+    public bool Equals(TimeOnlyValue other) => _valueOrThrow == other._valueOrThrow;
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator ==(TimeOnlyValue left, TimeOnlyValue right) => left.Equals(right);
@@ -86,7 +89,7 @@ public readonly partial struct TimeOnlyValue : IEquatable<TimeOnlyValue>
     }
 
     /// <inheritdoc/>
-    public int CompareTo(TimeOnlyValue other) => _value.CompareTo(other._value);
+    public int CompareTo(TimeOnlyValue other) => _valueOrThrow.CompareTo(other._valueOrThrow);
 
     /// <summary>
     /// Implicit conversion from <see cref = "TimeOnly"/> to <see cref = "TimeOnlyValue"/>
@@ -105,20 +108,20 @@ public readonly partial struct TimeOnlyValue : IEquatable<TimeOnlyValue>
     /// Implicit conversion from <see cref = "TimeOnlyValue"/> to <see cref = "TimeOnly"/>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator TimeOnly(TimeOnlyValue value) => (TimeOnly)value._value;
+    public static implicit operator TimeOnly(TimeOnlyValue value) => (TimeOnly)value._valueOrThrow;
 
     /// <summary>
     /// Implicit conversion from <see cref = "TimeOnlyValue"/> (nullable) to <see cref = "TimeOnly"/> (nullable)
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [return: NotNullIfNotNull(nameof(value))]
-    public static implicit operator TimeOnly?(TimeOnlyValue? value) => value is null ? null : (TimeOnly?)value.Value._value;
+    public static implicit operator TimeOnly?(TimeOnlyValue? value) => value is null ? null : (TimeOnly?)value.Value._valueOrThrow;
 
     /// <summary>
     /// Implicit conversion from <see cref = "TimeOnlyValue"/> to <see cref = "DateTime"/>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator DateTime(TimeOnlyValue value) => ((TimeOnly)value._value).ToDateTime();
+    public static implicit operator DateTime(TimeOnlyValue value) => ((TimeOnly)value._valueOrThrow).ToDateTime();
 
     /// <summary>
     /// Implicit conversion from <see cref = "DateTime"/> to <see cref = "TimeOnlyValue"/>
@@ -128,19 +131,19 @@ public readonly partial struct TimeOnlyValue : IEquatable<TimeOnlyValue>
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <(TimeOnlyValue left, TimeOnlyValue right) => left._value < right._value;
+    public static bool operator <(TimeOnlyValue left, TimeOnlyValue right) => left._valueOrThrow < right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <=(TimeOnlyValue left, TimeOnlyValue right) => left._value <= right._value;
+    public static bool operator <=(TimeOnlyValue left, TimeOnlyValue right) => left._valueOrThrow <= right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >(TimeOnlyValue left, TimeOnlyValue right) => left._value > right._value;
+    public static bool operator >(TimeOnlyValue left, TimeOnlyValue right) => left._valueOrThrow > right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >=(TimeOnlyValue left, TimeOnlyValue right) => left._value >= right._value;
+    public static bool operator >=(TimeOnlyValue left, TimeOnlyValue right) => left._valueOrThrow >= right._valueOrThrow;
 
 
     /// <inheritdoc/>
@@ -171,13 +174,13 @@ public readonly partial struct TimeOnlyValue : IEquatable<TimeOnlyValue>
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public string ToString(string? format, IFormatProvider? formatProvider) => _value.ToString(format, formatProvider);
+    public string ToString(string? format, IFormatProvider? formatProvider) => _valueOrThrow.ToString(format, formatProvider);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
     {
-        return ((ISpanFormattable)_value).TryFormat(destination, out charsWritten, format, provider);
+        return ((ISpanFormattable)_valueOrThrow).TryFormat(destination, out charsWritten, format, provider);
     }
 
 
@@ -186,67 +189,67 @@ public readonly partial struct TimeOnlyValue : IEquatable<TimeOnlyValue>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
     {
-        return ((IUtf8SpanFormattable)_value).TryFormat(utf8Destination, out bytesWritten, format, provider);
+        return ((IUtf8SpanFormattable)_valueOrThrow).TryFormat(utf8Destination, out bytesWritten, format, provider);
     }
 #endif
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override int GetHashCode() => _value.GetHashCode();
+    public override int GetHashCode() => _valueOrThrow.GetHashCode();
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    TypeCode IConvertible.GetTypeCode() => ((IConvertible)((TimeOnly)_value).ToDateTime()).GetTypeCode();
+    TypeCode IConvertible.GetTypeCode() => ((IConvertible)((TimeOnly)_valueOrThrow).ToDateTime()).GetTypeCode();
 
     /// <inheritdoc/>
-    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)((TimeOnly)_value).ToDateTime()).ToBoolean(provider);
+    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)((TimeOnly)_valueOrThrow).ToDateTime()).ToBoolean(provider);
 
     /// <inheritdoc/>
-    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)((TimeOnly)_value).ToDateTime()).ToByte(provider);
+    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)((TimeOnly)_valueOrThrow).ToDateTime()).ToByte(provider);
 
     /// <inheritdoc/>
-    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)((TimeOnly)_value).ToDateTime()).ToChar(provider);
+    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)((TimeOnly)_valueOrThrow).ToDateTime()).ToChar(provider);
 
     /// <inheritdoc/>
-    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)((TimeOnly)_value).ToDateTime()).ToDateTime(provider);
+    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)((TimeOnly)_valueOrThrow).ToDateTime()).ToDateTime(provider);
 
     /// <inheritdoc/>
-    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)((TimeOnly)_value).ToDateTime()).ToDecimal(provider);
+    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)((TimeOnly)_valueOrThrow).ToDateTime()).ToDecimal(provider);
 
     /// <inheritdoc/>
-    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)((TimeOnly)_value).ToDateTime()).ToDouble(provider);
+    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)((TimeOnly)_valueOrThrow).ToDateTime()).ToDouble(provider);
 
     /// <inheritdoc/>
-    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)((TimeOnly)_value).ToDateTime()).ToInt16(provider);
+    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)((TimeOnly)_valueOrThrow).ToDateTime()).ToInt16(provider);
 
     /// <inheritdoc/>
-    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)((TimeOnly)_value).ToDateTime()).ToInt32(provider);
+    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)((TimeOnly)_valueOrThrow).ToDateTime()).ToInt32(provider);
 
     /// <inheritdoc/>
-    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)((TimeOnly)_value).ToDateTime()).ToInt64(provider);
+    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)((TimeOnly)_valueOrThrow).ToDateTime()).ToInt64(provider);
 
     /// <inheritdoc/>
-    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)((TimeOnly)_value).ToDateTime()).ToSByte(provider);
+    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)((TimeOnly)_valueOrThrow).ToDateTime()).ToSByte(provider);
 
     /// <inheritdoc/>
-    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)((TimeOnly)_value).ToDateTime()).ToSingle(provider);
+    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)((TimeOnly)_valueOrThrow).ToDateTime()).ToSingle(provider);
 
     /// <inheritdoc/>
-    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)((TimeOnly)_value).ToDateTime()).ToString(provider);
+    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)((TimeOnly)_valueOrThrow).ToDateTime()).ToString(provider);
 
     /// <inheritdoc/>
-    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)((TimeOnly)_value).ToDateTime()).ToType(conversionType, provider);
+    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)((TimeOnly)_valueOrThrow).ToDateTime()).ToType(conversionType, provider);
 
     /// <inheritdoc/>
-    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)((TimeOnly)_value).ToDateTime()).ToUInt16(provider);
+    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)((TimeOnly)_valueOrThrow).ToDateTime()).ToUInt16(provider);
 
     /// <inheritdoc/>
-    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)((TimeOnly)_value).ToDateTime()).ToUInt32(provider);
+    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)((TimeOnly)_valueOrThrow).ToDateTime()).ToUInt32(provider);
 
     /// <inheritdoc/>
-    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)((TimeOnly)_value).ToDateTime()).ToUInt64(provider);
+    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)((TimeOnly)_valueOrThrow).ToDateTime()).ToUInt64(provider);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override string ToString() => _value.ToString();
+    public override string ToString() => _valueOrThrow.ToString();
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.TimeSpanValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.TimeSpanValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
@@ -36,16 +36,14 @@ public static class SwaggerTypeHelper
         {
             Type = "integer",
             Format = "int64",
-            Title = "TimeSpanValue",
-            Default = new OpenApiString(TimeSpanValue.Default.ToString("hh:mm:ss", null))
+            Title = "TimeSpanValue"
         });
         options.MapType<TimeSpanValue?>(() => new OpenApiSchema
         {
             Type = "integer",
             Format = "int64",
             Nullable = true,
-            Title = "Nullable<TimeSpanValue>",
-            Default = new OpenApiString(TimeSpanValue.Default.ToString("hh:mm:ss", null))
+            Title = "Nullable<TimeSpanValue>"
         });
     }
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.TimeSpanValue_GeneratesAllInterfacesAndConverters#TimeSpanValue.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.TimeSpanValue_GeneratesAllInterfacesAndConverters#TimeSpanValue.g.verified.cs
@@ -40,8 +40,11 @@ public readonly partial struct TimeSpanValue : IEquatable<TimeSpanValue>
     /// <inheritdoc/>
      public object GetUnderlyingPrimitiveValue() => (TimeSpan)this;
 
+    private TimeSpan _valueOrThrow => _isInitialized ? _value : throw new InvalidDomainValueException("The domain value has not been initialized");
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly TimeSpan _value;
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly bool _isInitialized;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TimeSpanValue"/> class by validating the specified <see cref="TimeSpan"/> value using <see cref="Validate"/> static method.
@@ -51,13 +54,13 @@ public readonly partial struct TimeSpanValue : IEquatable<TimeSpanValue>
     {
         Validate(value);
         _value = value;
+        _isInitialized = true;
     }
 
     /// <inheritdoc/>
     [Obsolete("Domain primitive cannot be created using empty Ctor", true)]
     public TimeSpanValue()
     {
-        _value = Default;
     }
 
     /// <inheritdoc/>
@@ -65,7 +68,7 @@ public readonly partial struct TimeSpanValue : IEquatable<TimeSpanValue>
     public override bool Equals(object? obj) => obj is TimeSpanValue other && Equals(other);
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Equals(TimeSpanValue other) => _value == other._value;
+    public bool Equals(TimeSpanValue other) => _valueOrThrow == other._valueOrThrow;
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator ==(TimeSpanValue left, TimeSpanValue right) => left.Equals(right);
@@ -86,7 +89,7 @@ public readonly partial struct TimeSpanValue : IEquatable<TimeSpanValue>
     }
 
     /// <inheritdoc/>
-    public int CompareTo(TimeSpanValue other) => _value.CompareTo(other._value);
+    public int CompareTo(TimeSpanValue other) => _valueOrThrow.CompareTo(other._valueOrThrow);
 
     /// <summary>
     /// Implicit conversion from <see cref = "TimeSpan"/> to <see cref = "TimeSpanValue"/>
@@ -105,30 +108,30 @@ public readonly partial struct TimeSpanValue : IEquatable<TimeSpanValue>
     /// Implicit conversion from <see cref = "TimeSpanValue"/> to <see cref = "TimeSpan"/>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator TimeSpan(TimeSpanValue value) => (TimeSpan)value._value;
+    public static implicit operator TimeSpan(TimeSpanValue value) => (TimeSpan)value._valueOrThrow;
 
     /// <summary>
     /// Implicit conversion from <see cref = "TimeSpanValue"/> (nullable) to <see cref = "TimeSpan"/> (nullable)
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [return: NotNullIfNotNull(nameof(value))]
-    public static implicit operator TimeSpan?(TimeSpanValue? value) => value is null ? null : (TimeSpan?)value.Value._value;
+    public static implicit operator TimeSpan?(TimeSpanValue? value) => value is null ? null : (TimeSpan?)value.Value._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <(TimeSpanValue left, TimeSpanValue right) => left._value < right._value;
+    public static bool operator <(TimeSpanValue left, TimeSpanValue right) => left._valueOrThrow < right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <=(TimeSpanValue left, TimeSpanValue right) => left._value <= right._value;
+    public static bool operator <=(TimeSpanValue left, TimeSpanValue right) => left._valueOrThrow <= right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >(TimeSpanValue left, TimeSpanValue right) => left._value > right._value;
+    public static bool operator >(TimeSpanValue left, TimeSpanValue right) => left._valueOrThrow > right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >=(TimeSpanValue left, TimeSpanValue right) => left._value >= right._value;
+    public static bool operator >=(TimeSpanValue left, TimeSpanValue right) => left._valueOrThrow >= right._valueOrThrow;
 
 
     /// <inheritdoc/>
@@ -159,13 +162,13 @@ public readonly partial struct TimeSpanValue : IEquatable<TimeSpanValue>
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public string ToString(string? format, IFormatProvider? formatProvider) => _value.ToString(format, formatProvider);
+    public string ToString(string? format, IFormatProvider? formatProvider) => _valueOrThrow.ToString(format, formatProvider);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
     {
-        return ((ISpanFormattable)_value).TryFormat(destination, out charsWritten, format, provider);
+        return ((ISpanFormattable)_valueOrThrow).TryFormat(destination, out charsWritten, format, provider);
     }
 
 
@@ -174,67 +177,67 @@ public readonly partial struct TimeSpanValue : IEquatable<TimeSpanValue>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
     {
-        return ((IUtf8SpanFormattable)_value).TryFormat(utf8Destination, out bytesWritten, format, provider);
+        return ((IUtf8SpanFormattable)_valueOrThrow).TryFormat(utf8Destination, out bytesWritten, format, provider);
     }
 #endif
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override int GetHashCode() => _value.GetHashCode();
+    public override int GetHashCode() => _valueOrThrow.GetHashCode();
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(TimeSpan)_value).GetTypeCode();
+    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(TimeSpan)_valueOrThrow).GetTypeCode();
 
     /// <inheritdoc/>
-    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(TimeSpan)_value).ToBoolean(provider);
+    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(TimeSpan)_valueOrThrow).ToBoolean(provider);
 
     /// <inheritdoc/>
-    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(TimeSpan)_value).ToByte(provider);
+    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(TimeSpan)_valueOrThrow).ToByte(provider);
 
     /// <inheritdoc/>
-    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(TimeSpan)_value).ToChar(provider);
+    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(TimeSpan)_valueOrThrow).ToChar(provider);
 
     /// <inheritdoc/>
-    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(TimeSpan)_value).ToDateTime(provider);
+    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(TimeSpan)_valueOrThrow).ToDateTime(provider);
 
     /// <inheritdoc/>
-    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(TimeSpan)_value).ToDecimal(provider);
+    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(TimeSpan)_valueOrThrow).ToDecimal(provider);
 
     /// <inheritdoc/>
-    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(TimeSpan)_value).ToDouble(provider);
+    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(TimeSpan)_valueOrThrow).ToDouble(provider);
 
     /// <inheritdoc/>
-    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(TimeSpan)_value).ToInt16(provider);
+    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(TimeSpan)_valueOrThrow).ToInt16(provider);
 
     /// <inheritdoc/>
-    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(TimeSpan)_value).ToInt32(provider);
+    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(TimeSpan)_valueOrThrow).ToInt32(provider);
 
     /// <inheritdoc/>
-    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(TimeSpan)_value).ToInt64(provider);
+    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(TimeSpan)_valueOrThrow).ToInt64(provider);
 
     /// <inheritdoc/>
-    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(TimeSpan)_value).ToSByte(provider);
+    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(TimeSpan)_valueOrThrow).ToSByte(provider);
 
     /// <inheritdoc/>
-    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(TimeSpan)_value).ToSingle(provider);
+    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(TimeSpan)_valueOrThrow).ToSingle(provider);
 
     /// <inheritdoc/>
-    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(TimeSpan)_value).ToString(provider);
+    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(TimeSpan)_valueOrThrow).ToString(provider);
 
     /// <inheritdoc/>
-    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(TimeSpan)_value).ToType(conversionType, provider);
+    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(TimeSpan)_valueOrThrow).ToType(conversionType, provider);
 
     /// <inheritdoc/>
-    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(TimeSpan)_value).ToUInt16(provider);
+    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(TimeSpan)_valueOrThrow).ToUInt16(provider);
 
     /// <inheritdoc/>
-    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(TimeSpan)_value).ToUInt32(provider);
+    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(TimeSpan)_valueOrThrow).ToUInt32(provider);
 
     /// <inheritdoc/>
-    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(TimeSpan)_value).ToUInt64(provider);
+    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(TimeSpan)_valueOrThrow).ToUInt64(provider);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override string ToString() => _value.ToString();
+    public override string ToString() => _valueOrThrow.ToString();
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.UInt16Value_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.UInt16Value_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
@@ -36,16 +36,14 @@ public static class SwaggerTypeHelper
         {
             Type = "integer",
             Format = "uint16",
-            Title = "UShortValue",
-            Default = new OpenApiInteger((short)UShortValue.Default)
+            Title = "UShortValue"
         });
         options.MapType<UShortValue?>(() => new OpenApiSchema
         {
             Type = "integer",
             Format = "uint16",
             Nullable = true,
-            Title = "Nullable<UShortValue>",
-            Default = new OpenApiInteger((short)UShortValue.Default)
+            Title = "Nullable<UShortValue>"
         });
     }
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.UInt16Value_GeneratesAllInterfacesAndConverters#UShortValue.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.UInt16Value_GeneratesAllInterfacesAndConverters#UShortValue.g.verified.cs
@@ -39,8 +39,11 @@ public readonly partial struct UShortValue : IEquatable<UShortValue>
     /// <inheritdoc/>
      public object GetUnderlyingPrimitiveValue() => (ushort)this;
 
+    private ushort _valueOrThrow => _isInitialized ? _value : throw new InvalidDomainValueException("The domain value has not been initialized");
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly ushort _value;
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly bool _isInitialized;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="UShortValue"/> class by validating the specified <see cref="ushort"/> value using <see cref="Validate"/> static method.
@@ -50,13 +53,13 @@ public readonly partial struct UShortValue : IEquatable<UShortValue>
     {
         Validate(value);
         _value = value;
+        _isInitialized = true;
     }
 
     /// <inheritdoc/>
     [Obsolete("Domain primitive cannot be created using empty Ctor", true)]
     public UShortValue()
     {
-        _value = Default;
     }
 
     /// <inheritdoc/>
@@ -64,7 +67,7 @@ public readonly partial struct UShortValue : IEquatable<UShortValue>
     public override bool Equals(object? obj) => obj is UShortValue other && Equals(other);
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Equals(UShortValue other) => _value == other._value;
+    public bool Equals(UShortValue other) => _valueOrThrow == other._valueOrThrow;
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator ==(UShortValue left, UShortValue right) => left.Equals(right);
@@ -85,7 +88,7 @@ public readonly partial struct UShortValue : IEquatable<UShortValue>
     }
 
     /// <inheritdoc/>
-    public int CompareTo(UShortValue other) => _value.CompareTo(other._value);
+    public int CompareTo(UShortValue other) => _valueOrThrow.CompareTo(other._valueOrThrow);
 
     /// <summary>
     /// Implicit conversion from <see cref = "ushort"/> to <see cref = "UShortValue"/>
@@ -104,30 +107,30 @@ public readonly partial struct UShortValue : IEquatable<UShortValue>
     /// Implicit conversion from <see cref = "UShortValue"/> to <see cref = "ushort"/>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator ushort(UShortValue value) => (ushort)value._value;
+    public static implicit operator ushort(UShortValue value) => (ushort)value._valueOrThrow;
 
     /// <summary>
     /// Implicit conversion from <see cref = "UShortValue"/> (nullable) to <see cref = "ushort"/> (nullable)
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [return: NotNullIfNotNull(nameof(value))]
-    public static implicit operator ushort?(UShortValue? value) => value is null ? null : (ushort?)value.Value._value;
+    public static implicit operator ushort?(UShortValue? value) => value is null ? null : (ushort?)value.Value._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <(UShortValue left, UShortValue right) => left._value < right._value;
+    public static bool operator <(UShortValue left, UShortValue right) => left._valueOrThrow < right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <=(UShortValue left, UShortValue right) => left._value <= right._value;
+    public static bool operator <=(UShortValue left, UShortValue right) => left._valueOrThrow <= right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >(UShortValue left, UShortValue right) => left._value > right._value;
+    public static bool operator >(UShortValue left, UShortValue right) => left._valueOrThrow > right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >=(UShortValue left, UShortValue right) => left._value >= right._value;
+    public static bool operator >=(UShortValue left, UShortValue right) => left._valueOrThrow >= right._valueOrThrow;
 
 
     /// <inheritdoc/>
@@ -161,67 +164,67 @@ public readonly partial struct UShortValue : IEquatable<UShortValue>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
     {
-        return ((IUtf8SpanFormattable)_value).TryFormat(utf8Destination, out bytesWritten, format, provider);
+        return ((IUtf8SpanFormattable)_valueOrThrow).TryFormat(utf8Destination, out bytesWritten, format, provider);
     }
 #endif
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override int GetHashCode() => _value.GetHashCode();
+    public override int GetHashCode() => _valueOrThrow.GetHashCode();
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(UInt16)_value).GetTypeCode();
+    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(UInt16)_valueOrThrow).GetTypeCode();
 
     /// <inheritdoc/>
-    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(UInt16)_value).ToBoolean(provider);
+    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(UInt16)_valueOrThrow).ToBoolean(provider);
 
     /// <inheritdoc/>
-    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(UInt16)_value).ToByte(provider);
+    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(UInt16)_valueOrThrow).ToByte(provider);
 
     /// <inheritdoc/>
-    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(UInt16)_value).ToChar(provider);
+    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(UInt16)_valueOrThrow).ToChar(provider);
 
     /// <inheritdoc/>
-    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(UInt16)_value).ToDateTime(provider);
+    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(UInt16)_valueOrThrow).ToDateTime(provider);
 
     /// <inheritdoc/>
-    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(UInt16)_value).ToDecimal(provider);
+    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(UInt16)_valueOrThrow).ToDecimal(provider);
 
     /// <inheritdoc/>
-    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(UInt16)_value).ToDouble(provider);
+    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(UInt16)_valueOrThrow).ToDouble(provider);
 
     /// <inheritdoc/>
-    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(UInt16)_value).ToInt16(provider);
+    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(UInt16)_valueOrThrow).ToInt16(provider);
 
     /// <inheritdoc/>
-    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(UInt16)_value).ToInt32(provider);
+    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(UInt16)_valueOrThrow).ToInt32(provider);
 
     /// <inheritdoc/>
-    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(UInt16)_value).ToInt64(provider);
+    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(UInt16)_valueOrThrow).ToInt64(provider);
 
     /// <inheritdoc/>
-    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(UInt16)_value).ToSByte(provider);
+    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(UInt16)_valueOrThrow).ToSByte(provider);
 
     /// <inheritdoc/>
-    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(UInt16)_value).ToSingle(provider);
+    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(UInt16)_valueOrThrow).ToSingle(provider);
 
     /// <inheritdoc/>
-    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(UInt16)_value).ToString(provider);
+    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(UInt16)_valueOrThrow).ToString(provider);
 
     /// <inheritdoc/>
-    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(UInt16)_value).ToType(conversionType, provider);
+    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(UInt16)_valueOrThrow).ToType(conversionType, provider);
 
     /// <inheritdoc/>
-    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(UInt16)_value).ToUInt16(provider);
+    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(UInt16)_valueOrThrow).ToUInt16(provider);
 
     /// <inheritdoc/>
-    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(UInt16)_value).ToUInt32(provider);
+    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(UInt16)_valueOrThrow).ToUInt32(provider);
 
     /// <inheritdoc/>
-    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(UInt16)_value).ToUInt64(provider);
+    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(UInt16)_valueOrThrow).ToUInt64(provider);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override string ToString() => _value.ToString();
+    public override string ToString() => _valueOrThrow.ToString();
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.UIntValue_GeneratesAllInterfacesAndConverters#IntValue.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.UIntValue_GeneratesAllInterfacesAndConverters#IntValue.g.verified.cs
@@ -44,8 +44,11 @@ public readonly partial struct IntValue : IEquatable<IntValue>
     /// <inheritdoc/>
      public object GetUnderlyingPrimitiveValue() => (uint)this;
 
+    private uint _valueOrThrow => _isInitialized ? _value : throw new InvalidDomainValueException("The domain value has not been initialized");
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly uint _value;
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly bool _isInitialized;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="IntValue"/> class by validating the specified <see cref="uint"/> value using <see cref="Validate"/> static method.
@@ -55,13 +58,13 @@ public readonly partial struct IntValue : IEquatable<IntValue>
     {
         Validate(value);
         _value = value;
+        _isInitialized = true;
     }
 
     /// <inheritdoc/>
     [Obsolete("Domain primitive cannot be created using empty Ctor", true)]
     public IntValue()
     {
-        _value = Default;
     }
 
     /// <inheritdoc/>
@@ -69,7 +72,7 @@ public readonly partial struct IntValue : IEquatable<IntValue>
     public override bool Equals(object? obj) => obj is IntValue other && Equals(other);
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Equals(IntValue other) => _value == other._value;
+    public bool Equals(IntValue other) => _valueOrThrow == other._valueOrThrow;
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator ==(IntValue left, IntValue right) => left.Equals(right);
@@ -90,7 +93,7 @@ public readonly partial struct IntValue : IEquatable<IntValue>
     }
 
     /// <inheritdoc/>
-    public int CompareTo(IntValue other) => _value.CompareTo(other._value);
+    public int CompareTo(IntValue other) => _valueOrThrow.CompareTo(other._valueOrThrow);
 
     /// <summary>
     /// Implicit conversion from <see cref = "uint"/> to <see cref = "IntValue"/>
@@ -109,50 +112,50 @@ public readonly partial struct IntValue : IEquatable<IntValue>
     /// Implicit conversion from <see cref = "IntValue"/> to <see cref = "uint"/>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator uint(IntValue value) => (uint)value._value;
+    public static implicit operator uint(IntValue value) => (uint)value._valueOrThrow;
 
     /// <summary>
     /// Implicit conversion from <see cref = "IntValue"/> (nullable) to <see cref = "uint"/> (nullable)
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [return: NotNullIfNotNull(nameof(value))]
-    public static implicit operator uint?(IntValue? value) => value is null ? null : (uint?)value.Value._value;
+    public static implicit operator uint?(IntValue? value) => value is null ? null : (uint?)value.Value._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static IntValue operator +(IntValue left, IntValue right) => new(left._value + right._value);
+    public static IntValue operator +(IntValue left, IntValue right) => new(left._valueOrThrow + right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static IntValue operator -(IntValue left, IntValue right) => new(left._value - right._value);
+    public static IntValue operator -(IntValue left, IntValue right) => new(left._valueOrThrow - right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static IntValue operator *(IntValue left, IntValue right) => new(left._value * right._value);
+    public static IntValue operator *(IntValue left, IntValue right) => new(left._valueOrThrow * right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static IntValue operator /(IntValue left, IntValue right) => new(left._value / right._value);
+    public static IntValue operator /(IntValue left, IntValue right) => new(left._valueOrThrow / right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static IntValue operator %(IntValue left, IntValue right) => new(left._value % right._value);
+    public static IntValue operator %(IntValue left, IntValue right) => new(left._valueOrThrow % right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <(IntValue left, IntValue right) => left._value < right._value;
+    public static bool operator <(IntValue left, IntValue right) => left._valueOrThrow < right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <=(IntValue left, IntValue right) => left._value <= right._value;
+    public static bool operator <=(IntValue left, IntValue right) => left._valueOrThrow <= right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >(IntValue left, IntValue right) => left._value > right._value;
+    public static bool operator >(IntValue left, IntValue right) => left._valueOrThrow > right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >=(IntValue left, IntValue right) => left._value >= right._value;
+    public static bool operator >=(IntValue left, IntValue right) => left._valueOrThrow >= right._valueOrThrow;
 
 
     /// <inheritdoc/>
@@ -186,67 +189,67 @@ public readonly partial struct IntValue : IEquatable<IntValue>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
     {
-        return ((IUtf8SpanFormattable)_value).TryFormat(utf8Destination, out bytesWritten, format, provider);
+        return ((IUtf8SpanFormattable)_valueOrThrow).TryFormat(utf8Destination, out bytesWritten, format, provider);
     }
 #endif
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override int GetHashCode() => _value.GetHashCode();
+    public override int GetHashCode() => _valueOrThrow.GetHashCode();
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(UInt32)_value).GetTypeCode();
+    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(UInt32)_valueOrThrow).GetTypeCode();
 
     /// <inheritdoc/>
-    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(UInt32)_value).ToBoolean(provider);
+    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(UInt32)_valueOrThrow).ToBoolean(provider);
 
     /// <inheritdoc/>
-    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(UInt32)_value).ToByte(provider);
+    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(UInt32)_valueOrThrow).ToByte(provider);
 
     /// <inheritdoc/>
-    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(UInt32)_value).ToChar(provider);
+    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(UInt32)_valueOrThrow).ToChar(provider);
 
     /// <inheritdoc/>
-    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(UInt32)_value).ToDateTime(provider);
+    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(UInt32)_valueOrThrow).ToDateTime(provider);
 
     /// <inheritdoc/>
-    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(UInt32)_value).ToDecimal(provider);
+    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(UInt32)_valueOrThrow).ToDecimal(provider);
 
     /// <inheritdoc/>
-    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(UInt32)_value).ToDouble(provider);
+    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(UInt32)_valueOrThrow).ToDouble(provider);
 
     /// <inheritdoc/>
-    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(UInt32)_value).ToInt16(provider);
+    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(UInt32)_valueOrThrow).ToInt16(provider);
 
     /// <inheritdoc/>
-    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(UInt32)_value).ToInt32(provider);
+    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(UInt32)_valueOrThrow).ToInt32(provider);
 
     /// <inheritdoc/>
-    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(UInt32)_value).ToInt64(provider);
+    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(UInt32)_valueOrThrow).ToInt64(provider);
 
     /// <inheritdoc/>
-    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(UInt32)_value).ToSByte(provider);
+    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(UInt32)_valueOrThrow).ToSByte(provider);
 
     /// <inheritdoc/>
-    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(UInt32)_value).ToSingle(provider);
+    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(UInt32)_valueOrThrow).ToSingle(provider);
 
     /// <inheritdoc/>
-    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(UInt32)_value).ToString(provider);
+    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(UInt32)_valueOrThrow).ToString(provider);
 
     /// <inheritdoc/>
-    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(UInt32)_value).ToType(conversionType, provider);
+    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(UInt32)_valueOrThrow).ToType(conversionType, provider);
 
     /// <inheritdoc/>
-    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(UInt32)_value).ToUInt16(provider);
+    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(UInt32)_valueOrThrow).ToUInt16(provider);
 
     /// <inheritdoc/>
-    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(UInt32)_value).ToUInt32(provider);
+    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(UInt32)_valueOrThrow).ToUInt32(provider);
 
     /// <inheritdoc/>
-    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(UInt32)_value).ToUInt64(provider);
+    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(UInt32)_valueOrThrow).ToUInt64(provider);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override string ToString() => _value.ToString();
+    public override string ToString() => _valueOrThrow.ToString();
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.UIntValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.UIntValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
@@ -36,16 +36,14 @@ public static class SwaggerTypeHelper
         {
             Type = "integer",
             Format = "uint32",
-            Title = "IntValue",
-            Default = new OpenApiInteger((int)IntValue.Default)
+            Title = "IntValue"
         });
         options.MapType<IntValue?>(() => new OpenApiSchema
         {
             Type = "integer",
             Format = "uint32",
             Nullable = true,
-            Title = "Nullable<IntValue>",
-            Default = new OpenApiInteger((int)IntValue.Default)
+            Title = "Nullable<IntValue>"
         });
     }
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.ULongValue_GeneratesAllInterfacesAndConverters#LongValue.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.ULongValue_GeneratesAllInterfacesAndConverters#LongValue.g.verified.cs
@@ -44,8 +44,11 @@ public readonly partial struct LongValue : IEquatable<LongValue>
     /// <inheritdoc/>
      public object GetUnderlyingPrimitiveValue() => (ulong)this;
 
+    private ulong _valueOrThrow => _isInitialized ? _value : throw new InvalidDomainValueException("The domain value has not been initialized");
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly ulong _value;
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly bool _isInitialized;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="LongValue"/> class by validating the specified <see cref="ulong"/> value using <see cref="Validate"/> static method.
@@ -55,13 +58,13 @@ public readonly partial struct LongValue : IEquatable<LongValue>
     {
         Validate(value);
         _value = value;
+        _isInitialized = true;
     }
 
     /// <inheritdoc/>
     [Obsolete("Domain primitive cannot be created using empty Ctor", true)]
     public LongValue()
     {
-        _value = Default;
     }
 
     /// <inheritdoc/>
@@ -69,7 +72,7 @@ public readonly partial struct LongValue : IEquatable<LongValue>
     public override bool Equals(object? obj) => obj is LongValue other && Equals(other);
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Equals(LongValue other) => _value == other._value;
+    public bool Equals(LongValue other) => _valueOrThrow == other._valueOrThrow;
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool operator ==(LongValue left, LongValue right) => left.Equals(right);
@@ -90,7 +93,7 @@ public readonly partial struct LongValue : IEquatable<LongValue>
     }
 
     /// <inheritdoc/>
-    public int CompareTo(LongValue other) => _value.CompareTo(other._value);
+    public int CompareTo(LongValue other) => _valueOrThrow.CompareTo(other._valueOrThrow);
 
     /// <summary>
     /// Implicit conversion from <see cref = "ulong"/> to <see cref = "LongValue"/>
@@ -109,50 +112,50 @@ public readonly partial struct LongValue : IEquatable<LongValue>
     /// Implicit conversion from <see cref = "LongValue"/> to <see cref = "ulong"/>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static implicit operator ulong(LongValue value) => (ulong)value._value;
+    public static implicit operator ulong(LongValue value) => (ulong)value._valueOrThrow;
 
     /// <summary>
     /// Implicit conversion from <see cref = "LongValue"/> (nullable) to <see cref = "ulong"/> (nullable)
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [return: NotNullIfNotNull(nameof(value))]
-    public static implicit operator ulong?(LongValue? value) => value is null ? null : (ulong?)value.Value._value;
+    public static implicit operator ulong?(LongValue? value) => value is null ? null : (ulong?)value.Value._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static LongValue operator +(LongValue left, LongValue right) => new(left._value + right._value);
+    public static LongValue operator +(LongValue left, LongValue right) => new(left._valueOrThrow + right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static LongValue operator -(LongValue left, LongValue right) => new(left._value - right._value);
+    public static LongValue operator -(LongValue left, LongValue right) => new(left._valueOrThrow - right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static LongValue operator *(LongValue left, LongValue right) => new(left._value * right._value);
+    public static LongValue operator *(LongValue left, LongValue right) => new(left._valueOrThrow * right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static LongValue operator /(LongValue left, LongValue right) => new(left._value / right._value);
+    public static LongValue operator /(LongValue left, LongValue right) => new(left._valueOrThrow / right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static LongValue operator %(LongValue left, LongValue right) => new(left._value % right._value);
+    public static LongValue operator %(LongValue left, LongValue right) => new(left._valueOrThrow % right._valueOrThrow);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <(LongValue left, LongValue right) => left._value < right._value;
+    public static bool operator <(LongValue left, LongValue right) => left._valueOrThrow < right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator <=(LongValue left, LongValue right) => left._value <= right._value;
+    public static bool operator <=(LongValue left, LongValue right) => left._valueOrThrow <= right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >(LongValue left, LongValue right) => left._value > right._value;
+    public static bool operator >(LongValue left, LongValue right) => left._valueOrThrow > right._valueOrThrow;
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool operator >=(LongValue left, LongValue right) => left._value >= right._value;
+    public static bool operator >=(LongValue left, LongValue right) => left._valueOrThrow >= right._valueOrThrow;
 
 
     /// <inheritdoc/>
@@ -186,67 +189,67 @@ public readonly partial struct LongValue : IEquatable<LongValue>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
     {
-        return ((IUtf8SpanFormattable)_value).TryFormat(utf8Destination, out bytesWritten, format, provider);
+        return ((IUtf8SpanFormattable)_valueOrThrow).TryFormat(utf8Destination, out bytesWritten, format, provider);
     }
 #endif
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override int GetHashCode() => _value.GetHashCode();
+    public override int GetHashCode() => _valueOrThrow.GetHashCode();
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(UInt64)_value).GetTypeCode();
+    TypeCode IConvertible.GetTypeCode() => ((IConvertible)(UInt64)_valueOrThrow).GetTypeCode();
 
     /// <inheritdoc/>
-    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(UInt64)_value).ToBoolean(provider);
+    bool IConvertible.ToBoolean(IFormatProvider? provider) => ((IConvertible)(UInt64)_valueOrThrow).ToBoolean(provider);
 
     /// <inheritdoc/>
-    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(UInt64)_value).ToByte(provider);
+    byte IConvertible.ToByte(IFormatProvider? provider) => ((IConvertible)(UInt64)_valueOrThrow).ToByte(provider);
 
     /// <inheritdoc/>
-    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(UInt64)_value).ToChar(provider);
+    char IConvertible.ToChar(IFormatProvider? provider) => ((IConvertible)(UInt64)_valueOrThrow).ToChar(provider);
 
     /// <inheritdoc/>
-    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(UInt64)_value).ToDateTime(provider);
+    DateTime IConvertible.ToDateTime(IFormatProvider? provider) => ((IConvertible)(UInt64)_valueOrThrow).ToDateTime(provider);
 
     /// <inheritdoc/>
-    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(UInt64)_value).ToDecimal(provider);
+    decimal IConvertible.ToDecimal(IFormatProvider? provider) => ((IConvertible)(UInt64)_valueOrThrow).ToDecimal(provider);
 
     /// <inheritdoc/>
-    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(UInt64)_value).ToDouble(provider);
+    double IConvertible.ToDouble(IFormatProvider? provider) => ((IConvertible)(UInt64)_valueOrThrow).ToDouble(provider);
 
     /// <inheritdoc/>
-    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(UInt64)_value).ToInt16(provider);
+    short IConvertible.ToInt16(IFormatProvider? provider) => ((IConvertible)(UInt64)_valueOrThrow).ToInt16(provider);
 
     /// <inheritdoc/>
-    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(UInt64)_value).ToInt32(provider);
+    int IConvertible.ToInt32(IFormatProvider? provider) => ((IConvertible)(UInt64)_valueOrThrow).ToInt32(provider);
 
     /// <inheritdoc/>
-    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(UInt64)_value).ToInt64(provider);
+    long IConvertible.ToInt64(IFormatProvider? provider) => ((IConvertible)(UInt64)_valueOrThrow).ToInt64(provider);
 
     /// <inheritdoc/>
-    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(UInt64)_value).ToSByte(provider);
+    sbyte IConvertible.ToSByte(IFormatProvider? provider) => ((IConvertible)(UInt64)_valueOrThrow).ToSByte(provider);
 
     /// <inheritdoc/>
-    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(UInt64)_value).ToSingle(provider);
+    float IConvertible.ToSingle(IFormatProvider? provider) => ((IConvertible)(UInt64)_valueOrThrow).ToSingle(provider);
 
     /// <inheritdoc/>
-    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(UInt64)_value).ToString(provider);
+    string IConvertible.ToString(IFormatProvider? provider) => ((IConvertible)(UInt64)_valueOrThrow).ToString(provider);
 
     /// <inheritdoc/>
-    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(UInt64)_value).ToType(conversionType, provider);
+    object IConvertible.ToType(Type conversionType, IFormatProvider? provider) => ((IConvertible)(UInt64)_valueOrThrow).ToType(conversionType, provider);
 
     /// <inheritdoc/>
-    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(UInt64)_value).ToUInt16(provider);
+    ushort IConvertible.ToUInt16(IFormatProvider? provider) => ((IConvertible)(UInt64)_valueOrThrow).ToUInt16(provider);
 
     /// <inheritdoc/>
-    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(UInt64)_value).ToUInt32(provider);
+    uint IConvertible.ToUInt32(IFormatProvider? provider) => ((IConvertible)(UInt64)_valueOrThrow).ToUInt32(provider);
 
     /// <inheritdoc/>
-    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(UInt64)_value).ToUInt64(provider);
+    ulong IConvertible.ToUInt64(IFormatProvider? provider) => ((IConvertible)(UInt64)_valueOrThrow).ToUInt64(provider);
 
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public override string ToString() => _value.ToString();
+    public override string ToString() => _valueOrThrow.ToString();
 }

--- a/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.ULongValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
+++ b/tests/AltaSoft.DomainPrimitives.Generator.Tests/Snapshots/DomainPrimitiveGeneratorTest.ULongValue_GeneratesAllInterfacesAndConverters#SwaggerTypeHelper.g.verified.cs
@@ -36,16 +36,14 @@ public static class SwaggerTypeHelper
         {
             Type = "integer",
             Format = "uint64",
-            Title = "LongValue",
-            Default = new OpenApiLong((long)LongValue.Default)
+            Title = "LongValue"
         });
         options.MapType<LongValue?>(() => new OpenApiSchema
         {
             Type = "integer",
             Format = "uint64",
             Nullable = true,
-            Title = "Nullable<LongValue>",
-            Default = new OpenApiLong((long)LongValue.Default)
+            Title = "Nullable<LongValue>"
         });
     }
 }

--- a/tests/AltaSoft.DomainPrimitives.XmlDataTypes.Tests/AsciiStringTests.cs
+++ b/tests/AltaSoft.DomainPrimitives.XmlDataTypes.Tests/AsciiStringTests.cs
@@ -25,14 +25,4 @@ public class AsciiStringTests
         // Act & Assert
         Assert.Throws<InvalidDomainValueException>(() => AsciiString.Validate(invalidString));
     }
-
-    [Fact]
-    public void Default_ReturnsEmptyString()
-    {
-        // Act
-        var defaultValue = AsciiString.Default;
-
-        // Assert
-        Assert.Equal(string.Empty, defaultValue);
-    }
 }

--- a/tests/AltaSoft.DomainPrimitives.XmlDataTypes.Tests/GDayTests.cs
+++ b/tests/AltaSoft.DomainPrimitives.XmlDataTypes.Tests/GDayTests.cs
@@ -19,16 +19,6 @@ public class GDayTests
         Assert.Null(exception);
     }
 
-    [Fact]
-    public void Default_ShouldReturnDefaultDateOnly()
-    {
-        // Act
-        var defaultDateOnly = GDay.Default;
-
-        // Assert
-        Assert.Equal(default, defaultDateOnly);
-    }
-
     [Theory]
     [InlineData(1, "01")]
     [InlineData(15, "15")]

--- a/tests/AltaSoft.DomainPrimitives.XmlDataTypes.Tests/GMonthDayTests.cs
+++ b/tests/AltaSoft.DomainPrimitives.XmlDataTypes.Tests/GMonthDayTests.cs
@@ -20,16 +20,6 @@ public class GMonthDayTests
         Assert.Null(exception);
     }
 
-    [Fact]
-    public void Default_ShouldReturnDefaultDateOnly()
-    {
-        // Act
-        var defaultDateOnly = GMonthDay.Default;
-
-        // Assert
-        Assert.Equal(default, defaultDateOnly);
-    }
-
     [Theory]
     [InlineData(1, 1, "01-01")]
     [InlineData(12, 31, "12-31")]

--- a/tests/AltaSoft.DomainPrimitives.XmlDataTypes.Tests/GMonthTests.cs
+++ b/tests/AltaSoft.DomainPrimitives.XmlDataTypes.Tests/GMonthTests.cs
@@ -19,16 +19,6 @@ public class GMonthTests
         Assert.Null(exception);
     }
 
-    [Fact]
-    public void Default_ShouldReturnDefaultDateOnly()
-    {
-        // Act
-        var defaultDateOnly = GMonth.Default;
-
-        // Assert
-        Assert.Equal(default, defaultDateOnly);
-    }
-
     [Theory]
     [InlineData(1, "01")]
     [InlineData(6, "06")]

--- a/tests/AltaSoft.DomainPrimitives.XmlDataTypes.Tests/GYearMonthTests.cs
+++ b/tests/AltaSoft.DomainPrimitives.XmlDataTypes.Tests/GYearMonthTests.cs
@@ -20,16 +20,6 @@ public class GYearMonthTests
         Assert.Null(exception);
     }
 
-    [Fact]
-    public void Default_ShouldReturnDefaultDateOnly()
-    {
-        // Act
-        var defaultDateOnly = GYearMonth.Default;
-
-        // Assert
-        Assert.Equal(default, defaultDateOnly);
-    }
-
     [Theory]
     [InlineData(2022, 1, "2022-01")]
     [InlineData(2024, 12, "2024-12")]

--- a/tests/AltaSoft.DomainPrimitives.XmlDataTypes.Tests/GYearTests.cs
+++ b/tests/AltaSoft.DomainPrimitives.XmlDataTypes.Tests/GYearTests.cs
@@ -19,16 +19,6 @@ public class GYearTests
         Assert.Null(exception);
     }
 
-    [Fact]
-    public void Default_ShouldReturnDefaultDateOnly()
-    {
-        // Act
-        var defaultDateOnly = GYear.Default;
-
-        // Assert
-        Assert.Equal(default, defaultDateOnly);
-    }
-
     [Theory]
     [InlineData(1968, "1968")]
     [InlineData(2000, "2000")]

--- a/tests/AltaSoft.DomainPrimitives.XmlDataTypes.Tests/NegativeIntegerTests.cs
+++ b/tests/AltaSoft.DomainPrimitives.XmlDataTypes.Tests/NegativeIntegerTests.cs
@@ -35,14 +35,4 @@ public class NegativeIntegerTests
         // Act & Assert
         Assert.Throws<InvalidDomainValueException>(() => NegativeInteger.Validate(value));
     }
-
-    [Fact]
-    public void NegativeInteger_DefaultValue_ShouldBeOne()
-    {
-        // Arrange
-        const int expectedValue = -1;
-
-        // Act & Assert
-        Assert.Equal(expectedValue, NegativeInteger.Default);
-    }
 }

--- a/tests/AltaSoft.DomainPrimitives.XmlDataTypes.Tests/NonEmptyStringTests.cs
+++ b/tests/AltaSoft.DomainPrimitives.XmlDataTypes.Tests/NonEmptyStringTests.cs
@@ -37,14 +37,4 @@ public class NonEmptyStringTests
         // Act & Assert
         Assert.Throws<InvalidDomainValueException>(() => NonEmptyString.Validate(emptyString));
     }
-
-    [Fact]
-    public void NonEmptyString_Default_ReturnsDefaultValue()
-    {
-        // Arrange
-        const string expectedDefaultValue = "N/A";
-
-        // Act & Assert
-        Assert.Equal(expectedDefaultValue, NonEmptyString.Default);
-    }
 }

--- a/tests/AltaSoft.DomainPrimitives.XmlDataTypes.Tests/NonNegativeIntegerTests.cs
+++ b/tests/AltaSoft.DomainPrimitives.XmlDataTypes.Tests/NonNegativeIntegerTests.cs
@@ -36,14 +36,4 @@ public class NonNegativeIntegerTests
         // Act & Assert
         Assert.Throws<InvalidDomainValueException>(() => NonNegativeInteger.Validate(value));
     }
-
-    [Fact]
-    public void NonNegativeInteger_DefaultValue_ShouldBeOne()
-    {
-        // Arrange
-        const int expectedValue = 0;
-
-        // Act & Assert
-        Assert.Equal(expectedValue, NonNegativeInteger.Default);
-    }
 }

--- a/tests/AltaSoft.DomainPrimitives.XmlDataTypes.Tests/NonPositiveIntegerTests.cs
+++ b/tests/AltaSoft.DomainPrimitives.XmlDataTypes.Tests/NonPositiveIntegerTests.cs
@@ -36,14 +36,4 @@ public class NonPositiveIntegerTests
         // Act & Assert
         Assert.Throws<InvalidDomainValueException>(() => NonPositiveInteger.Validate(value));
     }
-
-    [Fact]
-    public void NonPositiveInteger_DefaultValue_ShouldBeOne()
-    {
-        // Arrange
-        const int expectedValue = 0;
-
-        // Act & Assert
-        Assert.Equal(expectedValue, NonPositiveInteger.Default);
-    }
 }

--- a/tests/AltaSoft.DomainPrimitives.XmlDataTypes.Tests/PositiveIntegerTests.cs
+++ b/tests/AltaSoft.DomainPrimitives.XmlDataTypes.Tests/PositiveIntegerTests.cs
@@ -35,14 +35,4 @@ public class PositiveIntegerTests
         // Act & Assert
         Assert.Throws<InvalidDomainValueException>(() => PositiveInteger.Validate(value));
     }
-
-    [Fact]
-    public void PositiveInteger_DefaultValue_ShouldBeOne()
-    {
-        // Arrange
-        const int expectedValue = 1;
-
-        // Act & Assert
-        Assert.Equal(expectedValue, PositiveInteger.Default);
-    }
 }


### PR DESCRIPTION
The `Default` property and its usage have been removed. 
The `SwaggerTypeHelper` class has been updated to remove the `Default` property from the `OpenApiSchema` objects it creates for various types. 

A new class `StringLengthAttribute` was added, which is a validation attribute used to assert that a string property, field or parameter does not exceed a maximum length.
