### PR TITLE
Improved diagnostics for domain primitives and clean up Executor.cs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
 	<Product>Domain Primitives</Product>
 	<Company>ALTA Software llc.</Company>
 	<Copyright>Copyright © 2024 ALTA Software llc.</Copyright>
-	<Version>4.1.0</Version>
+	<Version>5.1.2</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/AltaSoft.DomainPrimitives.Generator/Executor.cs
+++ b/src/AltaSoft.DomainPrimitives.Generator/Executor.cs
@@ -145,6 +145,17 @@ internal static class Executor
             return null;
         }
 
+        if (underlyingType == DomainPrimitiveUnderlyingType.String && typeSymbol.TypeKind != TypeKind.Class)
+        {
+            context.ReportDiagnostic(DiagnosticHelper.InvalidClassTypeSpecified(typeSymbol.Locations.FirstOrDefault(), typeSymbol.Name));
+            return null;
+        }
+        if (underlyingType != DomainPrimitiveUnderlyingType.String && typeSymbol.TypeKind != TypeKind.Struct)
+        {
+            context.ReportDiagnostic(DiagnosticHelper.InvalidStructTypeSpecified(typeSymbol.Locations.FirstOrDefault(), underlyingType.ToString(), typeSymbol.Name));
+            return null;
+        }
+
         if (!isDateOrTime && serializationAttribute is not null)
         {
             context.ReportDiagnostic(DiagnosticHelper.TypeMustBeDateType(serializationAttribute.GetAttributeLocation(), typeSymbol.Name));
@@ -184,78 +195,6 @@ internal static class Executor
 
         return generatorData;
     }
-
-    //private static bool DefaultPropertyReturnsDefaultValue(IPropertySymbol property, DomainPrimitiveUnderlyingType underlyingType)
-    //{
-    //    var syntaxRefs = property.GetMethod?.DeclaringSyntaxReferences;
-    //    if (syntaxRefs is null)
-    //    {
-    //        // If there are no syntax references, the property doesn't have a getter
-    //        return false;
-    //    }
-
-    //    ExpressionSyntax? returnExpression = null;
-
-    //    foreach (var syntaxRef in syntaxRefs)
-    //    {
-    //        var syntaxNode = syntaxRef.GetSyntax();
-
-    //        // Handle expression-bodied properties
-    //        if (syntaxNode is ArrowExpressionClauseSyntax arrowExpressionClauseSyntax)
-    //        {
-    //            returnExpression = arrowExpressionClauseSyntax.Expression;
-    //            break;
-    //        }
-
-    //        // Handle expression-bodied properties
-    //        if (syntaxNode is PropertyDeclarationSyntax { ExpressionBody: { } expressionBody })
-    //        {
-    //            returnExpression = expressionBody.Expression;
-    //            break;
-    //        }
-
-    //        // Handle properties with getters that have a body
-    //        if (syntaxNode is AccessorDeclarationSyntax { Body: not null } accessorDeclaration)
-    //        {
-    //            var returnExpressions = accessorDeclaration.Body.DescendantNodes()
-    //                .OfType<ReturnStatementSyntax>()
-    //                .Select(r => r.Expression)
-    //                .ToArray();
-
-    //            if (returnExpressions.Length != 1)
-    //                return false;
-
-    //            returnExpression = returnExpressions[0];
-    //            break;
-    //        }
-    //    }
-
-    //    // Check if the return expression is a default value for the type
-    //    switch (returnExpression)
-    //    {
-    //        case null:
-    //            return false;
-
-    //        case DefaultExpressionSyntax:
-    //            return true;
-
-    //        // Simplified check for literal or default expressions
-    //        case LiteralExpressionSyntax literal:
-    //            if (literal.IsKind(SyntaxKind.DefaultLiteralExpression))
-    //                return true;
-
-    //            // Determine the default value for the property's type
-    //            var defaultValue = underlyingType.GetDefaultValue();
-    //            if (defaultValue is null)
-    //                return literal.Token.Value is null;
-
-    //            return defaultValue.Equals(literal.Token.Value);
-
-    //        // For more complex expressions, additional analysis is required
-    //        default:
-    //            return false;
-    //    }
-    //}
 
     /// <summary>
     /// Retrieves the SupportedOperationsAttributeData for a specified class, considering inheritance.

--- a/src/AltaSoft.DomainPrimitives.Generator/Helpers/DiagnosticHelper.cs
+++ b/src/AltaSoft.DomainPrimitives.Generator/Helpers/DiagnosticHelper.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.CodeAnalysis;
-using System;
+﻿using System;
+using Microsoft.CodeAnalysis;
 
 namespace AltaSoft.DomainPrimitives.Generator.Helpers;
 
@@ -9,23 +9,6 @@ namespace AltaSoft.DomainPrimitives.Generator.Helpers;
 internal static class DiagnosticHelper
 {
     private const string Category = "AltaSoft.DomainPrimitives.Generator";
-
-    ///// <summary>
-    ///// Creates a diagnostic indicating that the AltaSoft.DomainPrimitives.Generator has started.
-    ///// </summary>
-    ///// <returns>
-    ///// The created diagnostic.
-    ///// </returns>
-    //internal static Diagnostic GeneratorStarted()
-    //{
-    //    return Diagnostic.Create(new DiagnosticDescriptor(
-    //        "AL0000",
-    //        "AltaSoft.DomainPrimitives.Generator started",
-    //        "AltaSoft.DomainPrimitives.Generator started",
-    //        Category,
-    //        DiagnosticSeverity.Info,
-    //        isEnabledByDefault: true), null);
-    //}
 
     /// <summary>
     /// Creates a diagnostic for general error
@@ -205,5 +188,47 @@ internal static class DiagnosticHelper
                 Category,
                 DiagnosticSeverity.Error,
                 isEnabledByDefault: true), location, className);
+    }
+
+    /// <summary>
+    /// Creates a diagnostic indicating that the specified type must be a class 
+    /// to support domain primitive generation.
+    /// </summary>
+    /// <param name="location">The source location where the diagnostic should appear.</param>
+    /// <param name="className">The name of the type that is incorrectly used.</param>
+    /// <returns>
+    /// A diagnostic indicating that a domain primitive based on a string type must be a class.
+    /// </returns>
+    internal static Diagnostic InvalidClassTypeSpecified(Location? location, string className)
+    {
+        return Diagnostic.Create(
+            new DiagnosticDescriptor(
+                "AL1052",
+                "Domain primitive types based on string must be declared as classes",
+                "Type '{0}' must be declared as a class when using 'string' as the underlying domain primitive type.",
+                Category,
+                DiagnosticSeverity.Error,
+                isEnabledByDefault: true), location, className);
+    }
+    /// <summary>
+    /// Creates a diagnostic indicating that the specified type must be a struct 
+    /// to support domain primitive generation.
+    /// </summary>
+    /// <param name="location">The source location where the diagnostic should appear.</param>
+    /// <param name="typeName">The name of the underlying type used in the domain primitive.</param>
+    /// <param name="className">The name of the type that is incorrectly used.</param>
+    /// <returns>
+    /// A diagnostic indicating that a domain primitive based on <paramref name="typeName"/> must be a struct.
+    /// </returns>
+    internal static Diagnostic InvalidStructTypeSpecified(Location? location, string typeName, string className)
+    {
+        return Diagnostic.Create(
+            new DiagnosticDescriptor(
+                "AL1052",
+                $"Domain primitive types based on '{typeName}' must be declared as structs",
+                "Type '{0}' must be declared as a struct when using '{1}' as the underlying domain primitive type.",
+                Category,
+                DiagnosticSeverity.Error,
+                isEnabledByDefault: true), location, className, typeName);
     }
 }


### PR DESCRIPTION
- Add clearer error messages when domain primitive types are not declared as class or struct based on the underlying type.
- Remove unused commented code in Executor.cs.
- Add new diagnostic helpers for better clarity and maintainability.